### PR TITLE
New navigation for file picking

### DIFF
--- a/lib/app/bloc/directory/directorybloc.dart
+++ b/lib/app/bloc/directory/directorybloc.dart
@@ -93,6 +93,27 @@ class DirectoryBloc extends Bloc<DirectoryEvent, DirectoryState> {
 
       yield DirectoryLoadSuccess(contents: readFileResult.result, action: event.action);
     }
+
+    if (event is DeleteFile) {
+      yield DirectoryLoadInProgress();
+
+      try{
+        final deleteFileResult = await this.blocRepository.deleteFile(event.session, event.filePath);
+        if (deleteFileResult.errorMessage.isNotEmpty) 
+        {
+          print('The file (${event.filePath}) could not be deleted in repository ${event.session}');
+          yield DirectoryLoadFailure();
+
+          return;
+        }
+
+        yield await _getFolderContents(event.session, event.parentPath, false);
+
+      } catch (e) {
+        print('Exception deleting the file (${event.filePath}) in repository ${event.session}:\n${e.toString()}');
+        yield DirectoryLoadFailure();
+      }
+    }
   }
 
   Future<DirectoryState> _getFolderContents(Session session, String folderPath, bool recursive) async {

--- a/lib/app/bloc/directory/directoryevent.dart
+++ b/lib/app/bloc/directory/directoryevent.dart
@@ -93,3 +93,24 @@ class ReadFile extends DirectoryEvent {
   ];
 
 }
+
+class DeleteFile extends DirectoryEvent {
+  const DeleteFile({
+    required this.session,
+    required this.parentPath,
+    required this.filePath,
+  }) :
+  assert (filePath != '');
+
+  final Session session;
+  final String parentPath;
+  final String filePath;
+
+  @override
+  List<Object> get props => [
+    session,
+    parentPath,
+    filePath,
+  ];
+
+}

--- a/lib/app/controls/items/listitem.dart
+++ b/lib/app/controls/items/listitem.dart
@@ -77,11 +77,9 @@ class ListItem extends StatelessWidget {
   }
 
   IconButton _getActionByType(Function action) {
-    return itemData.itemType == ItemType.repo
-        ? IconButton(icon: const Icon(Icons.storage, size: 16.0,), onPressed: () => action.call())
-        : itemData.itemType == ItemType.folder
-        ? IconButton(icon: const Icon(Icons.arrow_forward_ios, size: 16.0,), onPressed: () => action.call())
-        : IconButton(icon: const Icon(Icons.more_vert, size: 24.0,), onPressed: () => action.call());
+    return itemData.itemType == ItemType.file
+        ? IconButton(icon: const Icon(Icons.more_vert, size: 24.0,), onPressed: () => action.call())
+        : IconButton(onPressed: null, icon: Container());
   }
 
 }

--- a/lib/app/controls/items/listitem.dart
+++ b/lib/app/controls/items/listitem.dart
@@ -8,7 +8,9 @@ class ListItem extends StatelessWidget {
   const ListItem({
     required this.itemData,
     required this.mainAction,
-    required this.popupAction,
+    required this.secondaryAction,
+    required this.popupMenu,
+    this.isDestination = false,
     this.isEncrypted = false,
     this.isLocal = true,
     this.isOwn = true,
@@ -16,7 +18,9 @@ class ListItem extends StatelessWidget {
 
   final BaseItem itemData;
   final Function mainAction;
-  final Function popupAction;
+  final Function secondaryAction;
+  final PopupMenuButton? popupMenu;
+  final bool isDestination;
   final bool isEncrypted;
   final bool isLocal;
   final bool isOwn;
@@ -34,7 +38,7 @@ class ListItem extends StatelessWidget {
             children: <Widget>[
               _getIconByType(),
               _getExpandedDescriptionByType(),
-              _getActionByType(popupAction),
+              _getActionByType(secondaryAction, popupMenu, isDestination),
             ],
           ),
         )
@@ -76,9 +80,15 @@ class ListItem extends StatelessWidget {
     );
   }
 
-  IconButton _getActionByType(Function action) {
+  Widget _getActionByType(Function secondaryAction, PopupMenuButton? popupMenu, bool isDestination) {
+    if (isDestination) {
+      return itemData.itemType == ItemType.folder
+        ? IconButton(icon: const Icon(Icons.arrow_forward_ios_outlined, size: 24.0,), onPressed: () => secondaryAction.call())
+        : IconButton(onPressed: null, icon: Container());
+    }
+
     return itemData.itemType == ItemType.file
-        ? IconButton(icon: const Icon(Icons.more_vert, size: 24.0,), onPressed: () => action.call())
+        ? popupMenu!
         : IconButton(onPressed: null, icon: Container());
   }
 

--- a/lib/app/controls/items/listitem.dart
+++ b/lib/app/controls/items/listitem.dart
@@ -7,31 +7,39 @@ import '../controls.dart';
 class ListItem extends StatelessWidget {
   const ListItem({
     required this.itemData,
-    required this.action,
+    required this.mainAction,
+    required this.popupAction,
     this.isEncrypted = false,
     this.isLocal = true,
     this.isOwn = true,
   });
 
   final BaseItem itemData;
-  final Function action;
+  final Function mainAction;
+  final Function popupAction;
   final bool isEncrypted;
   final bool isLocal;
   final bool isOwn;
 
   @override
   Widget build(BuildContext context) {
-    final container = Container(
-      padding: EdgeInsets.fromLTRB(8.0, 10.0, 2.0, 15.0),
-      color: _getColor(),
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: <Widget>[
-          _getIconByType(),
-          _getExpandedDescriptionByType(),
-          _getActionByType(action),
-        ],
+    final container = Material(
+      child: InkWell(
+        onTap:() => mainAction.call(),
+        splashColor: Colors.blue,
+        child: Container(
+          padding: EdgeInsets.fromLTRB(8.0, 10.0, 2.0, 15.0),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              _getIconByType(),
+              _getExpandedDescriptionByType(),
+              _getActionByType(popupAction),
+            ],
+          ),
+        )
       ),
+      color: _getColor(),
     );
 
     return itemData.itemType == ItemType.folder
@@ -60,7 +68,7 @@ class ListItem extends StatelessWidget {
           isEncrypted: isEncrypted,
           isLocal: isLocal,
           isOwn: isOwn,
-          action: action
+          action: mainAction
         )
         : itemData.itemType == ItemType.folder
         ? FolderDescription(folderData: itemData)

--- a/lib/app/data/repositories/directoryrepository.dart
+++ b/lib/app/data/repositories/directoryrepository.dart
@@ -144,6 +144,29 @@ class DirectoryRepository {
     return readFileResult;
   }
 
+  Future<BasicResult> deleteFile(Session session, String filePath) async {
+    BasicResult deleteFileResult;
+    String error = '';
+
+    final repository = await _openRepository(session);
+
+    try {
+      await File.remove(repository, filePath);
+    } catch (e) {
+      print('Exception deleting file $filePath:\n${e.toString()}');
+      error = 'Delete file $filePath failed';
+    } finally {
+      repository.close();
+    }
+
+    deleteFileResult = DeleteFileResult(functionName: 'deleteFile', result: 'OK');
+    if (error.isNotEmpty) {
+      deleteFileResult.errorMessage = error;
+    }
+
+    return deleteFileResult;
+  }
+
   Future<BasicResult> getContents(Session session, String path, bool recursive) async {
     print("Getting folder $path contents");
   

--- a/lib/app/pages/addfilepage.dart
+++ b/lib/app/pages/addfilepage.dart
@@ -12,11 +12,13 @@ class AddFilePage extends StatefulWidget {
   AddFilePage({
     required this.session,
     required this.parentPath,
+    required this.bloc,
     required this.title,
   });
 
   final Session session;
   final String parentPath;
+  final Bloc bloc;
   final String title;
 
   @override
@@ -56,7 +58,7 @@ class _AddFilePage extends State<AddFilePage> {
               : null;
             },
             onSaved: (newRepoName) {
-              BlocProvider.of<DirectoryBloc>(context)
+              widget.bloc
               .add(
                 CreateFile(
                   session: widget.session,

--- a/lib/app/pages/addfolderpage.dart
+++ b/lib/app/pages/addfolderpage.dart
@@ -9,11 +9,13 @@ class AddFolderPage extends StatefulWidget {
   AddFolderPage({
     required this.session,
     required this.path,
+    required this.bloc,
     required this.title,
   });
 
   final Session session;
   final String path;
+  final Bloc bloc;
   final String title;
 
   @override
@@ -53,7 +55,7 @@ class _AddFolderPage extends State<AddFolderPage> {
               ? '/$newFolderName'
               : '${widget.path}/$newFolderName';  
 
-              BlocProvider.of<DirectoryBloc>(context)
+              widget.bloc
               .add(
                 CreateFolder(
                   session: widget.session,

--- a/lib/app/pages/folderpage.dart
+++ b/lib/app/pages/folderpage.dart
@@ -177,11 +177,12 @@ class _FolderPageState extends State<FolderPage>
           final item = contents[index];
           return ListItem (
               itemData: item,
-              action: () => _actionByType(
+              mainAction: () => _actionByType(
                 widget.foldersRepository,
                 widget.path,
                 item
               ),
+              popupAction: () => {},
           );
         }
     );

--- a/lib/app/pages/folderpage.dart
+++ b/lib/app/pages/folderpage.dart
@@ -182,7 +182,13 @@ class _FolderPageState extends State<FolderPage>
                 widget.path,
                 item
               ),
-              popupAction: () => {},
+              secondaryAction: () => {},
+              popupMenu: Dialogs
+                .filePopupMenu(
+                  widget.session,
+                  BlocProvider. of<DirectoryBloc>(context),
+                  { 'Device': item }
+                ),
           );
         }
     );

--- a/lib/app/pages/receive_sharing_intent_page.dart
+++ b/lib/app/pages/receive_sharing_intent_page.dart
@@ -105,6 +105,9 @@ class _ReceiveSharingIntentPageState extends State<ReceiveSharingIntentPage>
           children: [
             _buildFileInfoHeader(),
             _contentNavigationButtons(),
+            Divider(
+              height: 10.0,
+            ),
             Expanded(
               flex: 1,
               child: _directoriesBlocBuilder()
@@ -281,7 +284,6 @@ class _ReceiveSharingIntentPageState extends State<ReceiveSharingIntentPage>
     mainAxisAlignment: MainAxisAlignment.center,
     crossAxisAlignment: CrossAxisAlignment.center,
     children: [
-      _buildFileInfoHeader(),
       Expanded(
         child: 
         Column(
@@ -305,7 +307,10 @@ class _ReceiveSharingIntentPageState extends State<ReceiveSharingIntentPage>
               child: Padding(
                 padding: EdgeInsets.fromLTRB(10.0, 0.0, 10.0, 0.0),
                 child: StyledText(
-                  text: messageCreateNewFolderToStartStyled,
+                  text: _currentFolder == '/'
+                  ? messageCreateNewFolderRootToStartStyled
+                  : messageCreateNewFolderStyled,
+                  textAlign: TextAlign.center,
                   style: TextStyle(
                     fontSize: 18.0,
                     fontWeight: FontWeight.normal
@@ -325,27 +330,26 @@ class _ReceiveSharingIntentPageState extends State<ReceiveSharingIntentPage>
 
   _contentsList(List<BaseItem> contents) {
     return ListView.separated(
-      shrinkWrap: true,
-        separatorBuilder: (context, index) => Divider(
-            height: 1,
-            color: Colors.transparent,
-        ),
-        itemCount: contents.length,
-        itemBuilder: (context, index) {
-          final item = contents[index];
-          return ListItem (
-              itemData: item,
-              mainAction: () {
-                if (item.itemType == ItemType.file) {
-                  return;
-                }  
+      separatorBuilder: (context, index) => Divider(
+          height: 1,
+          color: Colors.transparent,
+      ),
+      itemCount: contents.length,
+      itemBuilder: (context, index) {
+        final item = contents[index];
+        return ListItem (
+            itemData: item,
+            mainAction: () {
+              if (item.itemType == ItemType.file) {
+                return;
+              }  
 
-                final path = updateCurrentFolder(item.path);
-                getFolderContents(path);
-              },
-              popupAction: () => {},
-          );
-        }
+              final path = updateCurrentFolder(item.path);
+              getFolderContents(path);
+            },
+            popupAction: () => {},
+        );
+      }
     );
   }
 

--- a/lib/app/pages/receive_sharing_intent_page.dart
+++ b/lib/app/pages/receive_sharing_intent_page.dart
@@ -2,7 +2,6 @@ import 'dart:io' as io;
 
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:flutter_treeview/flutter_treeview.dart';
 import 'package:ouisync_plugin/ouisync_plugin.dart';
 import 'package:receive_sharing_intent/receive_sharing_intent.dart';
 import 'package:styled_text/styled_text.dart';
@@ -240,7 +239,7 @@ class _ReceiveSharingIntentPageState extends State<ReceiveSharingIntentPage>
                     fontWeight: FontWeight.bold,
                     fontStyle: FontStyle.italic,
                     color: Colors.white,
-                    backgroundColor: Colors.black
+                    backgroundColor: Colors.black,
                   ),
                 ),
               ),
@@ -344,34 +343,36 @@ class _ReceiveSharingIntentPageState extends State<ReceiveSharingIntentPage>
         final item = contents[index];
         return ListItem (
             itemData: item,
-            mainAction: () {
-              if (item.itemType == ItemType.file) {
-                return;
-              }  
-
+            mainAction: item.itemType == ItemType.file
+            ? () { }
+            : () { 
+              _saveFileToSelectedFolder(
+                item.path,
+                removePathFromFileName(widget.sharedFileInfo.single.path)
+              );
+            },
+            secondaryAction: item.itemType == ItemType.file
+            ? () { }
+            : () {
               final path = updateCurrentFolder(item.path);
               getFolderContents(path);
             },
-            popupAction: () => {},
+            popupMenu: Dialogs
+                .filePopupMenu(
+                  widget.session,
+                  BlocProvider. of<DirectoryBloc>(context),
+                  { 'Device': item }
+                ),
+            isDestination: true,
         );
       }
     );
   }
 
-  void _saveFileToSelectedFolder(Node<dynamic>? selectedNode, String key) {
-    final folderData = selectedNode!.data != null
-    ? selectedNode.data as FolderDescription
-    : Widget;
-    
-    final parentPath = key == 'ouisync_repo'
-    ? '/'
-    : (folderData as FolderDescription).folderData.path;
-    final fileName = removePathFromFileName(
-      '/${widget.sharedFileInfo.first.path}'
-    );
-    final destinationPath = parentPath == '/'
+  void _saveFileToSelectedFolder(String path, String fileName) {
+    final destinationPath = path == '/'
     ? '/$fileName'
-    : '$parentPath/$fileName';
+    : '$path/$fileName';
         
     _saveFileToOuiSync(widget.session, widget.directoryBlocPath, destinationPath);
   }

--- a/lib/app/pages/receive_sharing_intent_page.dart
+++ b/lib/app/pages/receive_sharing_intent_page.dart
@@ -216,7 +216,12 @@ class _ReceiveSharingIntentPageState extends State<ReceiveSharingIntentPage>
         crossAxisAlignment: CrossAxisAlignment.end,
         children: [
           TextButton(
-            child: Text('Back to ${getParentFolderFromCurrent()}'),
+            child: Text(
+              'Back to ${getParentFolderFromCurrent()}',
+              style: TextStyle(
+                fontSize: 18.0
+              ),
+            ),
             onPressed: atRoot()
             ? null
             : () { 

--- a/lib/app/pages/receive_sharing_intent_page.dart
+++ b/lib/app/pages/receive_sharing_intent_page.dart
@@ -105,7 +105,10 @@ class _ReceiveSharingIntentPageState extends State<ReceiveSharingIntentPage>
           children: [
             _buildFileInfoHeader(),
             _contentNavigationButtons(),
-            _directoriesBlocBuilder()
+            Expanded(
+              flex: 1,
+              child: _directoriesBlocBuilder()
+            ),
           ]
         ),
       ),

--- a/lib/app/pages/root_folder_page.dart
+++ b/lib/app/pages/root_folder_page.dart
@@ -226,7 +226,13 @@ class _RootFolderPageState extends State<RootFolderPage>
                 widget.path,
                 item
               ),
-              popupAction: () => {},
+              secondaryAction: () => {},
+              popupMenu: Dialogs
+                .filePopupMenu(
+                  widget.session,
+                  BlocProvider. of<DirectoryBloc>(context),
+                  { 'Device': item }
+                ),
           );
         }
     );

--- a/lib/app/pages/root_folder_page.dart
+++ b/lib/app/pages/root_folder_page.dart
@@ -221,11 +221,12 @@ class _RootFolderPageState extends State<RootFolderPage>
           final item = contents[index];
           return ListItem (
               itemData: item,
-              action: () => _actionByType(
+              mainAction: () => _actionByType(
                 widget.foldersRepository,
                 widget.path,
                 item
               ),
+              popupAction: () => {},
           );
         }
     );

--- a/lib/app/utils/actions.dart
+++ b/lib/app/utils/actions.dart
@@ -50,7 +50,12 @@ Future<void> printAppFolderContents(String path) async {
 
 String removePathFromFileName(String path) => path.split('/').last;
 
-String removeFileNameFromPath(String path) => path.substring(0, path.lastIndexOf('/')); 
+String extractParentFromPath(String path) {
+  final section = path.substring(0, path.lastIndexOf('/')); 
+  return section.isEmpty
+  ? '/'
+  : section;
+}
 
 dynamic extractNativeAttribute(List<String> attributesList, String attribute) => 
   attributesList.singleWhere((element) => element.startsWith('$attribute:')).split(':')[1];

--- a/lib/app/utils/basic_result.dart
+++ b/lib/app/utils/basic_result.dart
@@ -121,3 +121,16 @@ class ShareFileResult extends BasicResult {
   final List<int> result;
   final String action;
 }
+
+class DeleteFileResult extends BasicResult {
+  DeleteFileResult({
+    required this.functionName,
+    required this.result,
+  }) : super(
+    functionName: functionName,
+    result: result
+  );
+
+  final String functionName;
+  final String result;
+}

--- a/lib/app/utils/constants.dart
+++ b/lib/app/utils/constants.dart
@@ -28,8 +28,10 @@ const String messageNoRepos = 'No repositories found';
 const String messageEmptyRepo = 'This repository is empty';
 const String messageEmptyFolder = 'This folder is empty';
 const String messageEmptyFolderStructure = 'Move along, nothing to see here...';
-const String messageCreateNewFolderToStartStyled = 'Maybe start by creating a new folder using <bold>Actions</bold> <arrow_down/>'
+const String messageCreateNewFolderRootToStartStyled = 'Maybe start by creating a new folder using <bold>Actions</bold> <arrow_down/>'
 '\n... or just go ahead and use <bold>/</bold>, we are not your mother';
+const String messageCreateNewFolderStyled = 'You can create a new folder using <bold>Actions</bold> <arrow_down/>'
+'\n... or just drop it here, champ';
 
 const String messageCreateNewRepoStyled = 'Create a new repo using <bold>Actions</bold> <arrow_down/>';
 const String messageCreateAddNewObjectStyled = 'Create a new folder, or add a file, using <bold>Actions</bold> <arrow_down/>';

--- a/lib/app/utils/dialogs.dart
+++ b/lib/app/utils/dialogs.dart
@@ -3,6 +3,7 @@ import 'dart:math' as math;
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:ouisync_app/app/models/models.dart';
 import 'package:ouisync_plugin/ouisync_plugin.dart';
 
 import '../bloc/blocs.dart';
@@ -195,6 +196,29 @@ abstract class Dialogs {
       );
     }
   );
+
+  static filePopupMenu(Session session, Bloc bloc, Map<String, BaseItem> fileMenuOptions) {
+    return PopupMenuButton(
+      itemBuilder: (context) {
+        return fileMenuOptions.entries.map((e) => 
+          PopupMenuItem(
+              child: Text(e.key),
+              value: e,
+          ) 
+        ).toList();
+      },
+      onSelected: (value) {
+        final data = (value as MapEntry<String, BaseItem>).value;
+        bloc.add(
+          DeleteFile(
+            session: session,
+            parentPath: extractParentFromPath(data.path),
+            filePath: data.path
+          )
+        );
+      }
+    );
+  }
 
   static Future<void> showRequestStoragePermissionDialog(BuildContext context) async {
     Text title = Text('OuiSync - Storage permission needed');

--- a/lib/app/utils/dialogs.dart
+++ b/lib/app/utils/dialogs.dart
@@ -127,25 +127,21 @@ abstract class Dialogs {
     switch (action) {
       case actionNewFolder:
         dialogTitle = 'New Folder';
-        actionBody = BlocProvider(
-          create: (context) => directoryBloc,
-          child: AddFolderPage(
-            session: session,
-            path: parentPath,
-            title: 'New Folder',
-          ),
+        actionBody = AddFolderPage(
+          session: session,
+          path: parentPath,
+          bloc: directoryBloc,
+          title: 'New Folder',
         );
         break;
       
       case actionNewFile:
         dialogTitle = 'Add File';
-        actionBody = BlocProvider(
-          create: (context) => directoryBloc,
-          child: AddFilePage(
-            session: session,
-            parentPath: parentPath,
-            title: 'Add File',
-          ),
+        actionBody = AddFilePage(
+          session: session,
+          parentPath: parentPath,
+          bloc: directoryBloc,
+          title: 'Add File',
         );
         break;
         
@@ -165,24 +161,20 @@ abstract class Dialogs {
     switch (action) {
       case actionNewFile:
         dialogTitle = 'Add File';
-        actionBody = BlocProvider(
-          create: (context) => directoryBloc,
-          child: AddFilePage(
-            session: session,
-            parentPath: parentPath,
-            title: 'Add File',
-          ),
+        actionBody = AddFilePage(
+          session: session,
+          parentPath: parentPath,
+          bloc: directoryBloc,
+          title: 'Add File',
         );
         break;
       case actionNewFolder:
         dialogTitle = 'New Folder';
-        actionBody = BlocProvider(
-          create: (context) => directoryBloc,
-          child: AddFolderPage(
-            session: session,
-            path: parentPath,
-            title: 'New Folder',
-          ),
+        actionBody = AddFolderPage(
+          session: session,
+          path: parentPath,
+          bloc: directoryBloc,
+          title: 'New Folder',
         );
         break;
     }


### PR DESCRIPTION
- The tree view for picking a destination folder was replaced with a the pattern used for navigating the screens.

- The list item used for representing folders or files was updated to include main and secondary actions, and a popup menu was added, initially containing the delete option for files. 

- A bug with the directory bloc that caused that creating more than two folders in the root directory failed was fixed.