### PR TITLE
Inpage buttons share file destination

### DIFF
--- a/lib/app/controls/items/listitem.dart
+++ b/lib/app/controls/items/listitem.dart
@@ -83,7 +83,7 @@ class ListItem extends StatelessWidget {
   Widget _getActionByType(Function secondaryAction, PopupMenuButton? popupMenu, bool isDestination) {
     if (isDestination) {
       return itemData.itemType == ItemType.folder
-        ? IconButton(icon: const Icon(Icons.arrow_forward_ios_outlined, size: 24.0,), onPressed: () => secondaryAction.call())
+        ? IconButton(icon: const Icon(Icons.arrow_circle_down, size: 30.0,), onPressed: () => secondaryAction.call())
         : IconButton(onPressed: null, icon: Container());
     }
 

--- a/lib/app/hooks/hooks.dart
+++ b/lib/app/hooks/hooks.dart
@@ -1,0 +1,1 @@
+export 'scroll_controller_for_animation_hook.dart';

--- a/lib/app/hooks/scroll_controller_for_animation_hook.dart
+++ b/lib/app/hooks/scroll_controller_for_animation_hook.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/rendering.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+
+class _ScrollControllerForAnimationHook extends Hook<ScrollController> {
+  final AnimationController animationController;
+
+  const _ScrollControllerForAnimationHook({
+    required this.animationController,
+  });
+
+  @override
+  _ScrollControllerForAnimationHookState createState() =>
+      _ScrollControllerForAnimationHookState();
+}
+
+class _ScrollControllerForAnimationHookState
+    extends HookState<ScrollController, _ScrollControllerForAnimationHook> {
+  late ScrollController _scrollController;
+
+  @override
+  void initHook() {
+    _scrollController = ScrollController();
+    _scrollController.addListener(() {
+      switch (_scrollController.position.userScrollDirection) {
+        case ScrollDirection.forward:
+          // State has the "widget" property
+          // HookState has the "hook" property
+          hook.animationController.forward();
+          break;
+        case ScrollDirection.reverse:
+          hook.animationController.reverse();
+          break;
+        case ScrollDirection.idle:
+          break;
+      }
+    });
+  }
+
+  // Build doesn't return a Widget but rather the ScrollController
+  @override
+  ScrollController build(BuildContext context) => _scrollController;
+
+  // This is what we came here for
+  @override
+  void dispose() => _scrollController.dispose();
+}
+
+ScrollController useScrollControllerForAnimation(
+  AnimationController animationController,
+) {
+  return use(_ScrollControllerForAnimationHook(
+    animationController: animationController,
+  ));
+}

--- a/lib/app/pages/receive_sharing_intent_page.dart
+++ b/lib/app/pages/receive_sharing_intent_page.dart
@@ -76,7 +76,7 @@ class _ReceiveSharingIntentPageState extends State<ReceiveSharingIntentPage>
 
     return Scaffold(
       appBar: AppBar(
-        title: Text('Share file to OuiSync'),
+        title: Text('Add file to OuiSync'),
       ),
       body: Center(
         child: Column(

--- a/lib/app/pages/receive_sharing_intent_page.dart
+++ b/lib/app/pages/receive_sharing_intent_page.dart
@@ -303,25 +303,21 @@ class _ReceiveSharingIntentPageState extends State<ReceiveSharingIntentPage>
             mainAction: item.itemType == ItemType.file
             ? () { }
             : () { 
-              _saveFileToSelectedFolder(
-                item.path,
-                getPathFromFileName(widget.sharedFileInfo.single.path),
-                item
-              );
-            },
-            secondaryAction: item.itemType == ItemType.file
-            ? () { }
-            : () {
-               _navigateTo(
+              _navigateTo(
                 Navigation.folder,
                 extractParentFromPath(item.path),
                 item.path,
                 item //data
               );
-
-               setState(() {
-                _currentFolder = item.path;
-              });
+            },
+            secondaryAction: item.itemType == ItemType.file
+            ? () { }
+            : () {
+              _saveFileToSelectedFolder(
+                item.path,
+                getPathFromFileName(widget.sharedFileInfo.single.path),
+                item
+              );
             },
             popupMenu: Dialogs
                 .filePopupMenu(

--- a/lib/app/pages/receive_sharing_intent_page.dart
+++ b/lib/app/pages/receive_sharing_intent_page.dart
@@ -178,24 +178,28 @@ class _ReceiveSharingIntentPageState extends State<ReceiveSharingIntentPage>
             indent: 30.0,
             endIndent: 30.0,
           ),
-          Row(
-            children: [
-              Text(
-                'Where do you want to put it?',
-                textAlign: TextAlign.left,
-                style: TextStyle(
-                  fontSize: 24.0,
-                  fontWeight: FontWeight.bold
+          Padding(
+            padding: EdgeInsets.fromLTRB(10.0, 0.0, 10.0, 20.0),
+            child: Row(
+              children: [
+                Text(
+                  'Where do you want to put it?',
+                  textAlign: TextAlign.left,
+                  style: TextStyle(
+                    fontSize: 24.0,
+                    fontWeight: FontWeight.bold
+                  ),
                 ),
-              ),
-            ]
+              ]
+            ),
           ),
         ],
       ),
     );
   }
-
-  _navigationRoute() => BlocBuilder<RouteBloc, RouteState>(
+  
+  _navigationRoute() => BlocConsumer(
+    bloc: BlocProvider.of<RouteBloc>(context), 
     builder: (context, state) {
       if (state is RouteLoadSuccess) {
         return state.route;
@@ -204,6 +208,13 @@ class _ReceiveSharingIntentPageState extends State<ReceiveSharingIntentPage>
       return Container(
         child: Text('[!]]')
       );
+    },
+    listener: (context, state) {
+      if (state is RouteLoadSuccess) {
+        setState(() {
+          _currentFolder = state.path;
+        });
+      }
     }
   );
 

--- a/lib/app/pages/receive_sharing_intent_page.dart
+++ b/lib/app/pages/receive_sharing_intent_page.dart
@@ -118,66 +118,53 @@ class _ReceiveSharingIntentPageState extends State<ReceiveSharingIntentPage>
 
   _buildFileInfoHeader() { 
     return Padding(
-      padding: EdgeInsets.fromLTRB(10.0, 20.0, 10.0, 0.0),
+      padding: EdgeInsets.fromLTRB(10.0, 10.0, 10.0, 0.0),
       child: Column(
         children: [
-          Container(
-            padding: EdgeInsets.all(10.0),
-            constraints: BoxConstraints.tightForFinite(),
-            decoration: BoxDecoration(
-              borderRadius: BorderRadius.all(Radius.circular(10.0)),
-              color: Colors.blueGrey.shade50,
-              shape: BoxShape.rectangle,
-              boxShadow: [ 
-                BoxShadow(
-                  color: Colors.black12,
-                  offset: Offset(3.0, 3.0),
-                  blurRadius: 1.0,
-                  spreadRadius: 0.2,
-                ) 
-              ],
-            ),
-            child: Column(
-              children: [
-                Row(
-                  children: [
-                    const Icon(Icons.file_present),
-                    SizedBox(width: 10.0),
-                    Expanded(
-                      flex: 1,
-                      child: Text(
-                        fileName,
-                        textAlign: TextAlign.left,
-                        softWrap: true,
-                        overflow: TextOverflow.clip,
-                        style: TextStyle(
-                          fontSize: 18.0,
-                          fontWeight: FontWeight.bold
+          Card(
+            color: Colors.yellow.shade700,
+            child: Padding(
+              padding: EdgeInsets.fromLTRB(10.0, 10.0, 10.0, 20.0),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    children: [
+                      const Icon(
+                        Icons.file_present_rounded,
+                        size: 35.0,
+                      ),
+                      SizedBox(width: 2.0),
+                      Expanded(
+                        flex: 1,
+                        child: Text(
+                          fileName,
+                          textAlign: TextAlign.left,
+                          softWrap: true,
+                          overflow: TextOverflow.clip,
+                          style: TextStyle(
+                            fontSize: 18.0,
+                            fontWeight: FontWeight.bold
+                          ),
                         ),
                       ),
-                    ),
-                  ],
-                ),
-                SizedBox(height: 10.0),
-                Text(
-                  pathWithoutName,
-                  textAlign: TextAlign.start,
-                  softWrap: true,
-                  overflow: TextOverflow.clip,
-                  style: TextStyle(
-                    fontSize: 16.0,
+                    ],
                   ),
-                ),
-              ],
-            )
+                  SizedBox(height: 5.0),
+                  Text(
+                    pathWithoutName,
+                    textAlign: TextAlign.start,
+                    softWrap: true,
+                    overflow: TextOverflow.clip,
+                    style: TextStyle(
+                        fontSize: 16.0,
+                    ),
+                  ),
+                ],
+              )
+            ),
           ),
-          const Divider(
-            height: 40.0,
-            thickness: 1.0,
-            color: Colors.black12,
-            indent: 30.0,
-            endIndent: 30.0,
-          ),
+          const SizedBox(height: 20.0),
           Padding(
             padding: EdgeInsets.fromLTRB(10.0, 0.0, 10.0, 20.0),
             child: Row(

--- a/lib/app/pages/receive_sharing_intent_page.dart
+++ b/lib/app/pages/receive_sharing_intent_page.dart
@@ -94,17 +94,25 @@ class _ReceiveSharingIntentPageState extends State<ReceiveSharingIntentPage>
           ]
         ),
       ),
-      floatingActionButton: Dialogs.floatingActionsButtonMenu(
-        widget.directoryBloc,
-        widget.session,
-        context,
-        _controller,
-        widget.directoryBlocPath,//parentPath
-        receiveShareActions,
-        flagReceiveShareActionsDialog,
-        backgroundColor,
-        foregroundColor
-      ),
+      floatingActionButton: Container(
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.end,  
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            FloatingActionButton.extended(
+              onPressed: () {},
+              icon: const Icon(Icons.save_alt_rounded),
+              label: Text('Use $_currentFolder')
+            ),
+            SizedBox(width: 30.0),
+            FloatingActionButton.extended(
+              onPressed: () {},
+              icon: const Icon(Icons.create_new_folder_rounded),
+              label: const Text(actionNewFolder)
+            ),
+          ],
+        )
+      )
     );
   }
 

--- a/lib/app/pages/root_ouisync.dart
+++ b/lib/app/pages/root_ouisync.dart
@@ -116,7 +116,7 @@ class _RootOuiSyncState extends State<RootOuiSync>
     title: _getTitle(),
     centerTitle: true,
     bottom: PreferredSize(
-      preferredSize: Size.fromHeight(27.0),
+      preferredSize: Size.fromHeight(30.0),
       child: Container(
         child: _getRoute(),
       ),

--- a/lib/app/pages/root_ouisync.dart
+++ b/lib/app/pages/root_ouisync.dart
@@ -48,7 +48,7 @@ class _RootOuiSyncState extends State<RootOuiSync>
     handleIncomingShareIntent();
     initAnimationController();
 
-    loadRoot();
+    loadRoot(BlocProvider.of<NavigationBloc>(context));
   }
 
   @override
@@ -98,14 +98,6 @@ class _RootOuiSyncState extends State<RootOuiSync>
     vsync: this,
     duration: const Duration(milliseconds: actionsFloatingActionButtonAnimationDuration),
   );
-
-  loadRoot() => BlocProvider.of<NavigationBloc>(context)
-  .add(NavigateTo(
-      Navigation.folder,
-      widget.path,
-      slash,
-      FolderItem(creationDate: DateTime.now(), lastModificationDate: DateTime.now(), items: <BaseItem>[])
-  ));
 
   @override
   Widget build(BuildContext context) {

--- a/lib/app/utils/actions.dart
+++ b/lib/app/utils/actions.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:ouisync_app/app/models/models.dart';
 
 import '../bloc/blocs.dart';
 import 'utils.dart';
@@ -37,6 +38,15 @@ String extractFileTypeFromName(String fileName) {
   return fileName.substring(fileName.lastIndexOf('.') + 1);
 }
 
+loadRoot(bloc) => 
+bloc.add(
+  NavigateTo(
+    Navigation.folder,
+    slash,
+    slash,
+    FolderItem(creationDate: DateTime.now(), lastModificationDate: DateTime.now(), items: <BaseItem>[])
+  )
+);
 
 sectionWidget(text) => Container(
     decoration: BoxDecoration(

--- a/lib/app/utils/actions.dart
+++ b/lib/app/utils/actions.dart
@@ -80,7 +80,7 @@ sectionWidget(text) => Container(
   }
 
   buildRoute(route) => Padding(
-    padding: EdgeInsets.fromLTRB(0.0, 5.0, 0.0, 2.0),
+    padding: EdgeInsets.fromLTRB(0.0, 10.0, 0.0, 20.0),
     child: Row(
       children: route,
     ),

--- a/lib/app/utils/actions.dart
+++ b/lib/app/utils/actions.dart
@@ -90,7 +90,7 @@ sectionWidget(text) => Container(
   }
 
   buildRoute(route) => Padding(
-    padding: EdgeInsets.fromLTRB(0.0, 10.0, 0.0, 20.0),
+    padding: EdgeInsets.fromLTRB(0.0, 5.0, 0.0, 1.0),
     child: Row(
       children: route,
     ),

--- a/lib/app/utils/constants.dart
+++ b/lib/app/utils/constants.dart
@@ -55,8 +55,6 @@ const String actionNewFile = 'Add file';
 const String actionDeleteFolder = 'Delete folder';
 const String actionDeleteFile = 'Delete file';
 
-const String actionUseRoot = 'Use /';
-
 const String actionPreview = 'preview';
 const String actionShare = 'share';
 
@@ -65,10 +63,6 @@ const Map<String, IconData> folderActions = const {
   actionNewFolder: Icons.create_new_folder_rounded, 
   actionNewFile: Icons.file_upload,
   actionDeleteFolder: Icons.delete_sharp
-};
-const Map<String, IconData> receiveShareActions = const {
-  actionUseRoot: Icons.save_alt_rounded,
-  actionNewFolder: Icons.create_new_folder_rounded
 };
 
 const int bufferSize = 64000;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,6 +36,7 @@ dependencies:
   file: ^6.1.1
   file_picker: ^3.0.2+2
   flutter_bloc: ^7.0.0
+  flutter_hooks: ^0.18.0
   flutter_treeview: ^1.0.3+2
   mockito: ^5.0.10
   mocktail: ^0.1.4

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,10 +21,6 @@ environment:
   sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
-  flutter:
-    sdk: flutter
-  ouisync_plugin:
-    path: ../ouisync_plugin
   bloc: ^7.0.0
   bloc_test: ^8.0.2
   build_runner: ^2.0.5
@@ -35,12 +31,16 @@ dependencies:
   ffi: ^1.0.0
   file: ^6.1.1
   file_picker: ^3.0.2+2
+  flutter:
+    sdk: flutter
   flutter_bloc: ^7.1.0
   flutter_hooks: ^0.18.0
   flutter_treeview: ^1.0.3+2
   mockito: ^5.0.10
   mocktail: ^0.1.4
   open_file: ^3.2.1
+  ouisync_plugin:
+    path: ../ouisync_plugin
   path: ^1.8.0
   path_provider: ^2.0.1
   permission_handler: ^8.0.0+2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,11 +31,11 @@ dependencies:
   chunked_stream: ^1.4.1
   clock: ^1.1.0
   cupertino_icons: ^1.0.3
-  equatable: ^2.0.2
+  equatable: ^2.0.3
   ffi: ^1.0.0
   file: ^6.1.1
   file_picker: ^3.0.2+2
-  flutter_bloc: ^7.0.0
+  flutter_bloc: ^7.1.0
   flutter_hooks: ^0.18.0
   flutter_treeview: ^1.0.3+2
   mockito: ^5.0.10


### PR DESCRIPTION
When receiving an share intent for adding a file to OuiSync, the Actions button was replaced with individual buttons.

When the user scrolls, the buttons are hided, then made visible again when scrolling back up.
This way the folders contents can be seen without obstruction. 