### PR TITLE
Nagivation simplification

### DIFF
--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -12,12 +12,12 @@ class OuiSyncApp extends StatefulWidget {
   const OuiSyncApp({
     required this.session,
     required this.repository,
-    required this.foldersRepository,
+    required this.directoryRepository,
   });
 
   final Session session;
   final Repository repository;
-  final DirectoryRepository foldersRepository;
+  final DirectoryRepository directoryRepository;
 
   @override
   _OuiSyncAppState createState() => _OuiSyncAppState();
@@ -33,7 +33,9 @@ class _OuiSyncAppState extends State<OuiSyncApp> {
 
     NativeChannels.init(widget.session);
 
-    navigationBloc = NavigationBloc(rootPath: slash);
+    navigationBloc = NavigationBloc(
+      directoryRepository: widget.directoryRepository
+    );
   }
 
   @override
@@ -45,7 +47,7 @@ class _OuiSyncAppState extends State<OuiSyncApp> {
         ),
         BlocProvider<DirectoryBloc>(
           create: (BuildContext context) => DirectoryBloc(
-            blocRepository: widget.foldersRepository
+            blocRepository: widget.directoryRepository
           ),
         ),
         BlocProvider(
@@ -61,7 +63,7 @@ class _OuiSyncAppState extends State<OuiSyncApp> {
         ),
         home: RootOuiSync(
           repository: widget.repository,
-          foldersRepository: widget.foldersRepository,
+          directoryRepository: widget.directoryRepository,
           path: slash,
           title: titleApp,
         )

--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -63,7 +63,6 @@ class _OuiSyncAppState extends State<OuiSyncApp> {
         ),
         home: RootOuiSync(
           repository: widget.repository,
-          directoryRepository: widget.directoryRepository,
           path: slash,
           title: titleApp,
         )

--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -11,20 +11,18 @@ import 'utils/utils.dart';
 class OuiSyncApp extends StatefulWidget {
   const OuiSyncApp({
     required this.session,
-    required this.repository,
-    required this.directoryRepository,
+    required this.repository
   });
 
   final Session session;
   final Repository repository;
-  final DirectoryRepository directoryRepository;
 
   @override
   _OuiSyncAppState createState() => _OuiSyncAppState();
 }
 
 class _OuiSyncAppState extends State<OuiSyncApp> {
-
+  late final DirectoryRepository directoryRepository;
   late final NavigationBloc navigationBloc;
 
   @override
@@ -32,9 +30,14 @@ class _OuiSyncAppState extends State<OuiSyncApp> {
     super.initState();
 
     NativeChannels.init(widget.session);
+    initLateObjects();
+  }
 
+  void initLateObjects() {
+    directoryRepository = DirectoryRepository(repository: widget.repository);
+    
     navigationBloc = NavigationBloc(
-      directoryRepository: widget.directoryRepository
+      directoryRepository: directoryRepository
     );
   }
 
@@ -47,7 +50,7 @@ class _OuiSyncAppState extends State<OuiSyncApp> {
         ),
         BlocProvider<DirectoryBloc>(
           create: (BuildContext context) => DirectoryBloc(
-            blocRepository: widget.directoryRepository
+            blocRepository: directoryRepository
           ),
         ),
         BlocProvider(

--- a/lib/app/bloc/navigation/nav_bloc.dart
+++ b/lib/app/bloc/navigation/nav_bloc.dart
@@ -4,10 +4,10 @@ import '../blocs.dart';
 
 class NavigationBloc extends Bloc<NavigationEvent, NavigationState> {
   NavigationBloc({
-    required this.rootPath
+    required this.directoryRepository
   }) : super(NavigationInitial());
 
-  final String rootPath;
+  final DirectoryRepository directoryRepository;
 
   @override
   Stream<NavigationState> mapEventToState(NavigationEvent event) async* {

--- a/lib/app/bloc/navigation/nav_bloc.dart
+++ b/lib/app/bloc/navigation/nav_bloc.dart
@@ -13,7 +13,9 @@ class NavigationBloc extends Bloc<NavigationEvent, NavigationState> {
   @override
   Stream<NavigationState> mapEventToState(NavigationEvent event) async* {
     if (event is NavigateTo) {
-      yield NavigationLoadInProgress();
+      if (event.withProgress) {
+        yield NavigationLoadInProgress(); 
+      }
 
       try {
         final folderContentsResult = 

--- a/lib/app/bloc/navigation/nav_bloc.dart
+++ b/lib/app/bloc/navigation/nav_bloc.dart
@@ -1,4 +1,5 @@
 import 'package:bloc/bloc.dart';
+import 'package:ouisync_app/app/data/data.dart';
 
 import '../blocs.dart';
 
@@ -12,12 +13,28 @@ class NavigationBloc extends Bloc<NavigationEvent, NavigationState> {
   @override
   Stream<NavigationState> mapEventToState(NavigationEvent event) async* {
     if (event is NavigateTo) {
-      yield NavigationLoadSuccess(
-        type: event.type,
-        origin: event.origin,
-        destination: event.destination
-      );
+      yield NavigationLoadInProgress();
+
+      try {
+        final folderContentsResult = 
+          await this.directoryRepository
+          .getFolderContents(event.destination);
+
+        if (folderContentsResult.errorMessage.isNotEmpty) {
+          print('Get contents in folder $event.destination failed:\n${folderContentsResult.errorMessage}');
+          yield NavigationLoadFailure();
+        }
+
+        yield NavigationLoadSuccess(
+          type: event.type,
+          origin: event.origin,
+          destination: event.destination,
+          contents: folderContentsResult.result
+        );
+      } catch (e) {
+        print('Exception getting the directory\'s ${event.destination} contents:\n${e.toString()}');
+        yield NavigationLoadFailure();
+      }
     }
   }
-  
 }

--- a/lib/app/bloc/navigation/nav_event.dart
+++ b/lib/app/bloc/navigation/nav_event.dart
@@ -10,7 +10,8 @@ class NavigateTo extends NavigationEvent {
   const NavigateTo({
     required this.type,
     required this.origin,
-    required this.destination
+    required this.destination,
+    required this.withProgress
   }) : 
   assert (origin != ''),
   assert (destination != '');
@@ -18,11 +19,13 @@ class NavigateTo extends NavigationEvent {
   final Navigation type;
   final String origin;
   final String destination;
+  final bool withProgress;
 
   @override
   List<Object?> get props => [
     type,
     origin,
-    destination
+    destination,
+    withProgress
   ];
 }

--- a/lib/app/bloc/navigation/nav_state.dart
+++ b/lib/app/bloc/navigation/nav_state.dart
@@ -1,4 +1,5 @@
 import 'package:equatable/equatable.dart';
+import 'package:ouisync_app/app/models/models.dart';
 
 abstract class NavigationState extends Equatable {
   const NavigationState();
@@ -15,7 +16,8 @@ class NavigationLoadSuccess extends NavigationState {
   const NavigationLoadSuccess({
     required this.type,
     required this.origin,
-    required this.destination
+    required this.destination,
+    required this.contents
   }) :
   assert (origin != ''),
   assert (destination != '');
@@ -23,12 +25,14 @@ class NavigationLoadSuccess extends NavigationState {
   final Navigation type;
   final String origin;
   final String destination;
+  final List<BaseItem> contents;
 
   @override
   List<Object> get props => [
     type,
     origin,
-    destination
+    destination,
+    contents
   ];
 }
 

--- a/lib/app/bloc/route/route_bloc.dart
+++ b/lib/app/bloc/route/route_bloc.dart
@@ -74,7 +74,7 @@ class RouteBloc extends Bloc<RouteEvent, RouteState> {
       },
       child: path == slash
       ? const Icon(
-          Icons.folder_rounded,
+          Icons.lock_rounded,
           size: 30.0,
         )
       : const Icon(

--- a/lib/app/controls/dialogs/modal_folder_creation_dialog.dart
+++ b/lib/app/controls/dialogs/modal_folder_creation_dialog.dart
@@ -9,11 +9,13 @@ class FolderCreation extends StatelessWidget {
   const FolderCreation({
     Key? key,
     required this.bloc,
+    required this.updateUI,
     required this.path,
     required this.formKey
   }) : super(key: key);
 
   final Bloc bloc;
+  final Function updateUI;
   final String path;
   final GlobalKey<FormState> formKey;
 
@@ -49,7 +51,7 @@ class FolderCreation extends StatelessWidget {
         mainAxisSize: MainAxisSize.max,
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          buildEntry(context, 'Create a new folder: ', (value) => _onSaved(context, value)),
+          buildEntry(context, 'Create a new folder: ', (value) => _onSaved(context, value, updateUI)),
           buildInfoLabel('Location: ', this.path),
           buildActionsSection(context, _actions(context)),
         ]
@@ -57,7 +59,7 @@ class FolderCreation extends StatelessWidget {
     );
   }
 
-  void _onSaved(context, newFolderName) {
+  void _onSaved(context, newFolderName, updateUI) {
     final newFolderPath = this.path == slash
     ? '/$newFolderName'
     : '${this.path}/$newFolderName';  
@@ -69,6 +71,8 @@ class FolderCreation extends StatelessWidget {
         newFolderPath: newFolderPath
       )
     );
+
+    updateUI.call();
 
     Navigator.of(context).pop(true);
   }

--- a/lib/app/pages/receive_sharing_intent_page.dart
+++ b/lib/app/pages/receive_sharing_intent_page.dart
@@ -265,7 +265,7 @@ class _ReceiveSharingIntentPageState extends State<ReceiveSharingIntentPage>
                 messageEmptyFolderStructure,
                 textAlign: TextAlign.center,
                 style: TextStyle(
-                  fontSize: 24.0,
+                  fontSize: 23.0,
                   fontWeight: FontWeight.bold
                 ),
               ),
@@ -281,7 +281,7 @@ class _ReceiveSharingIntentPageState extends State<ReceiveSharingIntentPage>
                   : messageCreateNewFolderStyled,
                   textAlign: TextAlign.center,
                   style: TextStyle(
-                    fontSize: 18.0,
+                    fontSize: 17.0,
                     fontWeight: FontWeight.normal
                   ),
                   styles: {

--- a/lib/app/pages/receive_sharing_intent_page.dart
+++ b/lib/app/pages/receive_sharing_intent_page.dart
@@ -215,33 +215,35 @@ class _ReceiveSharingIntentPageState extends State<ReceiveSharingIntentPage>
 
   _directoriesBlocBuilder(ScrollController scrollController) {
     return Center(
-      child: BlocBuilder<DirectoryBloc, DirectoryState>(
+      child: BlocBuilder<NavigationBloc, NavigationState>(
         builder: (context, state) {
-          if (state is DirectoryInitial) {
+          if (state is NavigationInitial) {
             return Center(child: Text('Loading contents...'));
           }
 
-          if (state is DirectoryLoadInProgress){
+          if (state is NavigationLoadInProgress) {
             return Center(child: CircularProgressIndicator());
           }
 
-          if (state is DirectoryLoadSuccess) {
-            final contents = state.contents as List<BaseItem>;
+          if (state is NavigationLoadSuccess) {
+            if (state.contents.isEmpty) {
+              return _noContents();
+            }
+
+            final contents = state.contents;
             contents.sort((a, b) => a.itemType.index.compareTo(b.itemType.index));
 
-            return contents.isEmpty 
-            ? _noContents()
-            : _contentsList(contents, scrollController);
+            return _contentsList(contents, scrollController);
           }
 
-          if (state is DirectoryLoadFailure) {
+          if (state is NavigationLoadFailure) {
             return Text(
               'Something went wrong!',
               style: TextStyle(color: Colors.red),
             );
           }
 
-          return Center(child: Text('root'));
+          return Center(child: Text('Ooops!'));
         }
       )
     );

--- a/lib/app/pages/receive_sharing_intent_page.dart
+++ b/lib/app/pages/receive_sharing_intent_page.dart
@@ -377,7 +377,8 @@ class _ReceiveSharingIntentPageState extends State<ReceiveSharingIntentPage>
       NavigateTo(
         type: type,
         origin: origin,
-        destination: destination
+        destination: destination,
+        withProgress: true
       )
     );
   }

--- a/lib/app/pages/root_ouisync.dart
+++ b/lib/app/pages/root_ouisync.dart
@@ -33,7 +33,6 @@ class RootOuiSync extends StatefulWidget {
 class _RootOuiSyncState extends State<RootOuiSync>
   with TickerProviderStateMixin {
 
-  late final Repository repository;
   late final Subscription subscription;
 
   List<BaseItem> _folderContents = <BaseItem>[];

--- a/lib/app/pages/root_ouisync.dart
+++ b/lib/app/pages/root_ouisync.dart
@@ -19,13 +19,13 @@ import 'pages.dart';
 class RootOuiSync extends StatefulWidget {
   const RootOuiSync({
     required this.repository,
-    required this.foldersRepository,
+    required this.directoryRepository,
     required this.path,
     required this.title,
   });
 
   final Repository repository;
-  final DirectoryRepository foldersRepository;
+  final DirectoryRepository directoryRepository;
   final String path;
   final String title;
   

--- a/lib/app/pages/root_ouisync.dart
+++ b/lib/app/pages/root_ouisync.dart
@@ -264,56 +264,53 @@ class _RootOuiSyncState extends State<RootOuiSync>
       )
     );
 
-  _contentsList(List contents) {
-    updateFolderContents(contents);
-
-    return RefreshIndicator(
-      onRefresh: _reloadCurrentFolder,
-      child: ListView.separated(
-        separatorBuilder: (context, index) => Divider(
-            height: 1,
-            color: Colors.transparent
-        ),
-        itemCount: _folderContents.length,
-        itemBuilder: (context, index) {
-          final item = _folderContents[index];
-          final actionByType = item.itemType == ItemType.file
-          ? () async {
-            final file = await Dialogs.executeFutureWithLoadingDialog(
-              context,
-              getFile(item.path, item.name)
-            );
-            if (file != null) {
-              final size = await file.length;
-              _showFileDetails(item.name, item.path, size);
-            }
-          }
-          : () {
-            BlocProvider.of<NavigationBloc>(context)
-            .add(
-              NavigateTo(
-                type: Navigation.content,
-                origin: _currentFolder,
-                destination: item.path
-              )
-            );
-          };
-
-          return ListItem (
-              itemData: item,
-              mainAction: actionByType,
-              secondaryAction: () => {},
-              popupMenu: Dialogs
-                .filePopupMenu(
-                  context,
-                  BlocProvider. of<DirectoryBloc>(context),
-                  { actionDeleteFile: item }
-                ),
+  _contentsList(List<BaseItem> contents) => 
+  RefreshIndicator(
+    onRefresh: _reloadCurrentFolder,
+    child: ListView.separated(
+      separatorBuilder: (context, index) => Divider(
+          height: 1,
+          color: Colors.transparent
+      ),
+      itemCount: contents.length,
+      itemBuilder: (context, index) {
+        final item = contents[index];
+        final actionByType = item.itemType == ItemType.file
+        ? () async {
+          final file = await Dialogs.executeFutureWithLoadingDialog(
+            context,
+            getFile(item.path, item.name)
           );
+          if (file != null) {
+            final size = await file.length;
+            _showFileDetails(item.name, item.path, size);
+          }
         }
-      )
-    );
-  }
+        : () {
+          BlocProvider.of<NavigationBloc>(context)
+          .add(
+            NavigateTo(
+              type: Navigation.content,
+              origin: _currentFolder,
+              destination: item.path
+            )
+          );
+        };
+
+        return ListItem (
+            itemData: item,
+            mainAction: actionByType,
+            secondaryAction: () => {},
+            popupMenu: Dialogs
+              .filePopupMenu(
+                context,
+                BlocProvider. of<DirectoryBloc>(context),
+                { actionDeleteFile: item }
+              ),
+        );
+      }
+    )
+  );
 
   Future<void> updateFolderContents(items) async {
     if (items.isEmpty) {

--- a/lib/app/pages/root_ouisync.dart
+++ b/lib/app/pages/root_ouisync.dart
@@ -11,7 +11,6 @@ import 'package:styled_text/styled_text.dart';
 
 import '../bloc/blocs.dart';
 import '../controls/controls.dart';
-import '../data/data.dart';
 import '../models/models.dart';
 import '../utils/utils.dart';
 import 'pages.dart';
@@ -19,13 +18,11 @@ import 'pages.dart';
 class RootOuiSync extends StatefulWidget {
   const RootOuiSync({
     required this.repository,
-    required this.directoryRepository,
     required this.path,
     required this.title,
   });
 
   final Repository repository;
-  final DirectoryRepository directoryRepository;
   final String path;
   final String title;
   

--- a/lib/app/pages/root_ouisync.dart
+++ b/lib/app/pages/root_ouisync.dart
@@ -168,6 +168,7 @@ class _RootOuiSyncState extends State<RootOuiSync>
         if (state.type == Navigation.content) {
           setState(() { 
             _currentFolder = state.destination;
+            updateFolderContents(state.contents);
             print('Current path updated: $_currentFolder');
           });
 
@@ -214,7 +215,7 @@ class _RootOuiSyncState extends State<RootOuiSync>
       final contents = state.contents;
       contents.sort((a, b) => a.itemType.index.compareTo(b.itemType.index));
 
-      return _contentsList(contents);
+      return _contentsList();
     }
 
     if (state is NavigationLoadFailure) {
@@ -228,7 +229,7 @@ class _RootOuiSyncState extends State<RootOuiSync>
   }
 
   _noContents() => RefreshIndicator(
-      onRefresh: _reloadCurrentFolder,
+      onRefresh: () async => updateUI.call(),
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
         crossAxisAlignment: CrossAxisAlignment.center,
@@ -265,17 +266,17 @@ class _RootOuiSyncState extends State<RootOuiSync>
       )
     );
 
-  _contentsList(List<BaseItem> contents) => 
+  _contentsList() =>
   RefreshIndicator(
-    onRefresh: _reloadCurrentFolder,
+    onRefresh: () async => updateUI.call(),
     child: ListView.separated(
       separatorBuilder: (context, index) => Divider(
           height: 1,
           color: Colors.transparent
       ),
-      itemCount: contents.length,
+      itemCount: _folderContents.length,
       itemBuilder: (context, index) {
-        final item = contents[index];
+        final item = _folderContents[index];
         final actionByType = item.itemType == ItemType.file
         ? () async {
           final file = await Dialogs.executeFutureWithLoadingDialog(

--- a/lib/app/pages/root_ouisync.dart
+++ b/lib/app/pages/root_ouisync.dart
@@ -385,8 +385,9 @@ class _RootOuiSyncState extends State<RootOuiSync>
   );
 
   Widget _getFloatingButton() => Dialogs.floatingActionsButtonMenu(
-    BlocProvider.of<DirectoryBloc>(context),
     context,
+    BlocProvider.of<DirectoryBloc>(context),
+    updateUI,
     _controller,
     _currentFolder,
     folderActions,
@@ -394,5 +395,20 @@ class _RootOuiSyncState extends State<RootOuiSync>
     backgroundColor,
     foregroundColor
   );
+
+  void updateUI({bool withProgress = true}) {
+    final origin = extractParentFromPath(_currentFolder);
+    final destination = _currentFolder;
+
+    BlocProvider.of<NavigationBloc>(context)
+    .add(
+      NavigateTo(
+        type: Navigation.content,
+        origin: origin,
+        destination: destination,
+        withProgress: withProgress
+      )
+    );
+  }
 
 }

--- a/lib/app/pages/root_ouisync.dart
+++ b/lib/app/pages/root_ouisync.dart
@@ -112,7 +112,7 @@ class _RootOuiSyncState extends State<RootOuiSync>
     autoRefreshTimer = Timer.periodic(
       Duration(seconds: autoRefreshPeriodInSeconds),
       (timer) { 
-        _reloadCurrentFolder();
+        updateUI(withProgress: false);
       }
     );
   }
@@ -184,7 +184,8 @@ class _RootOuiSyncState extends State<RootOuiSync>
                   NavigateTo(
                     type: Navigation.content,
                     origin: from,
-                    destination: backTo
+                    destination: backTo,
+                    withProgress: true
                   )
                 );
               }
@@ -292,7 +293,8 @@ class _RootOuiSyncState extends State<RootOuiSync>
             NavigateTo(
               type: Navigation.content,
               origin: _currentFolder,
-              destination: item.path
+              destination: item.path,
+              withProgress: true
             )
           );
         };

--- a/lib/app/pages/root_ouisync.dart
+++ b/lib/app/pages/root_ouisync.dart
@@ -318,11 +318,9 @@ class _RootOuiSyncState extends State<RootOuiSync>
   Future<void> updateFolderContents(items) async {
     if (items.isEmpty) {
       if (_folderContents.isNotEmpty) {
-        SchedulerBinding.instance!.addPostFrameCallback((_) {
           setState(() {
             _folderContents.clear();
           }); 
-        });
       }
       return;
     }
@@ -331,23 +329,10 @@ class _RootOuiSyncState extends State<RootOuiSync>
     contents.sort((a, b) => a.itemType.index.compareTo(b.itemType.index));
     
     if (!DeepCollectionEquality.unordered().equals(contents, _folderContents)) {
-      SchedulerBinding.instance!.addPostFrameCallback((_) {
         setState(() {
           _folderContents = contents;
         });
-      });  
     }
-  }
-
-  Future<void> _reloadCurrentFolder() async {
-    BlocProvider.of<DirectoryBloc>(context)
-    .add(
-      RequestContent(
-        path: _currentFolder,
-        recursive: false,
-        withProgressIndicator: false
-      )
-    );
   }
 
   Future<File?> getFile(String path, String name) async {

--- a/lib/app/utils/actions.dart
+++ b/lib/app/utils/actions.dart
@@ -61,7 +61,8 @@ bloc.add(
   NavigateTo(
     type: Navigation.content,
     origin: slash,
-    destination: slash
+    destination: slash,
+    withProgress: true
   )
 );
 

--- a/lib/app/utils/dialogs.dart
+++ b/lib/app/utils/dialogs.dart
@@ -13,7 +13,7 @@ import 'utils.dart';
 
 abstract class Dialogs {
   static Future<dynamic> executeFutureWithLoadingDialog(BuildContext context, Future<dynamic> f) async {
-    _showLoadingDialog(context);
+    showLoadingDialog(context);
 
     var result = await f;
     _hideLoadingDialog(context);
@@ -22,18 +22,21 @@ abstract class Dialogs {
   }
 
   static void executeFunctionWithLoadingDialog(BuildContext context, Function f) {
-    _showLoadingDialog(context);
+    showLoadingDialog(context);
 
     f.call();
     _hideLoadingDialog(context);
   }
 
-  static _showLoadingDialog(BuildContext context) {
+  static showLoadingDialog(BuildContext context, { Widget widget = const Text("Loading..." ) }) {
     final alert = AlertDialog(
       content: new Row(
         children: [
           CircularProgressIndicator(),
-          Container(margin: EdgeInsets.only(left: 7),child:Text("Loading..." )),
+          Container(
+            margin: EdgeInsets.only(left: 7),
+            child:widget
+            ),
         ],
       ),
     );

--- a/lib/app/utils/dialogs.dart
+++ b/lib/app/utils/dialogs.dart
@@ -54,8 +54,9 @@ abstract class Dialogs {
     Navigator.pop(context);
 
   static Widget floatingActionsButtonMenu(
-    Bloc bloc,
     BuildContext context,
+    Bloc actionBloc,
+    Function updateUI,
     AnimationController controller,
     String path,
     Map<String, IconData> actions,
@@ -89,7 +90,7 @@ abstract class Dialogs {
               label: Text(actionName),
               icon: Icon(actions[actionName]),
               onPressed: () async => 
-                await executeActionByName(actionsDialog, controller, context, bloc, path, actionName),
+                await executeActionByName(actionsDialog, controller, context, actionBloc, updateUI, path, actionName),
             ),
           ),
         );
@@ -122,23 +123,31 @@ abstract class Dialogs {
     String actionsDialog,
     AnimationController controller,
     BuildContext context,
-    Bloc<dynamic, dynamic> bloc,
+    Bloc<dynamic, dynamic> actionBloc,
+    Function updateUI,
     String path,
     String actionName
   ) async {
     late Future<dynamic> dialog;
     switch (actionsDialog) {
-      case flagRepoActionsDialog:
-      /// Only one repository allowed for the MVP
-        // dialog = repoActionsDialog(context, bloc as RepositoryBloc, session, actionName);
-        break;
-    
       case flagFolderActionsDialog:
-        dialog = folderActionsDialog(context, bloc as DirectoryBloc, path, actionName);
+        dialog = folderActionsDialog(
+          context,
+          actionBloc as DirectoryBloc,
+          updateUI,
+          path,
+          actionName
+        );
         break;
     
       case flagReceiveShareActionsDialog:
-        dialog = receiveShareActionsDialog(context, bloc as DirectoryBloc, path, actionName);
+        dialog = receiveShareActionsDialog(
+          context,
+          actionBloc as DirectoryBloc,
+          updateUI,
+          path,
+          actionName
+        );
         break;
     
       default:
@@ -152,27 +161,13 @@ abstract class Dialogs {
     }
   }
 
-  static Future<dynamic> repoActionsDialog(BuildContext context, RepositoryBloc repositoryBloc, String action) {
-    String dialogTitle = '';
-    Widget? actionBody;
-
-    switch (action) {
-      case actionNewRepo:
-        dialogTitle = 'New Repository';
-        actionBody = AddRepoPage(
-          title: 'New Repository',
-        );
-        break;
-    }
-
-    return _actionDialog(
-      context,
-      dialogTitle,
-      actionBody
-    );
-  }
-
-  static Future<dynamic> folderActionsDialog(BuildContext context, DirectoryBloc directoryBloc, String path, String action) async {
+  static Future<dynamic> folderActionsDialog(
+    BuildContext context,
+    DirectoryBloc directoryBloc,
+    Function updateUI,
+    String path,
+    String action
+  ) async {
     String dialogTitle = '';
     Widget? actionBody;
 
@@ -183,6 +178,7 @@ abstract class Dialogs {
         dialogTitle = 'Create Folder';
         actionBody = FolderCreation(
           bloc: directoryBloc,
+          updateUI: updateUI,
           path: path,
           formKey: formKey,
         );
@@ -190,7 +186,7 @@ abstract class Dialogs {
       break;
       
       case actionNewFile: 
-        return await _addFileAction(path, directoryBloc);
+        return await _addFileAction(path, directoryBloc, updateUI);
 
       case actionDeleteFolder:
         final parentPath = extractParentFromPath(path);
@@ -201,10 +197,11 @@ abstract class Dialogs {
           builder: (BuildContext context) {
 
             return buildDeleteFolderAlertDialog(
+              context,
               directoryBloc,
+              updateUI,
               parentPath,
               path,
-              context,
             );
           },
         );
@@ -217,7 +214,7 @@ abstract class Dialogs {
     );
   }
 
-  static _addFileAction(String path, DirectoryBloc directoryBloc) async {
+  static _addFileAction(String path, DirectoryBloc directoryBloc, Function updateUI) async {
     final result = await FilePicker
     .platform
     .pickFiles(
@@ -240,6 +237,8 @@ abstract class Dialogs {
           fileByteStream: fileByteStream
         )
       );
+
+      updateUI.call();
       
       return Future.value(true);
     }
@@ -247,7 +246,7 @@ abstract class Dialogs {
     return Future.value(false);
   }
 
-  static AlertDialog buildDeleteFolderAlertDialog(bloc, parentPath, path, BuildContext context) {
+  static AlertDialog buildDeleteFolderAlertDialog(BuildContext context, bloc, updateUI, parentPath, path) {
     return AlertDialog(
       title: const Text('Delete folder'),
       content: SingleChildScrollView(
@@ -278,6 +277,8 @@ abstract class Dialogs {
                 path: path
               )
             );
+
+            updateUI.call();
     
             Navigator.of(context).pop(true);
           },
@@ -292,13 +293,19 @@ abstract class Dialogs {
     );
   }
 
-  static Future<dynamic> receiveShareActionsDialog(BuildContext context, DirectoryBloc directoryBloc, String parentPath, String action) async {
+  static Future<dynamic> receiveShareActionsDialog(
+    BuildContext context,
+    DirectoryBloc directoryBloc,
+    Function updateUI,
+    String parentPath,
+    String action
+  ) async {
     String dialogTitle = '';
     Widget? actionBody;
 
     switch (action) {
       case actionNewFile:
-        return await _addFileAction(parentPath, directoryBloc);
+        return await _addFileAction(parentPath, directoryBloc, updateUI);
         
       case actionNewFolder: {
           final formKey = GlobalKey<FormState>();
@@ -306,6 +313,7 @@ abstract class Dialogs {
           dialogTitle = 'Create Folder';
           actionBody = FolderCreation(
             bloc: directoryBloc,
+            updateUI: updateUI,
             path: parentPath,
             formKey: formKey,
           );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -16,7 +16,7 @@ Future<void> main() async {
 
   final repository = await Repository.open(session);
 
-  final DirectoryRepository foldersRepository = 
+  final DirectoryRepository directoryRepository = 
     DirectoryRepository(repository: repository);
 
   Bloc.observer = SimpleBlocObserver();
@@ -24,6 +24,6 @@ Future<void> main() async {
   runApp(OuiSyncApp(
       session: session,
       repository: repository,
-      foldersRepository: foldersRepository,
+      directoryRepository: directoryRepository,
     ));
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,7 +6,6 @@ import 'package:path_provider/path_provider.dart';
 
 import 'app/app.dart';
 import 'app/bloc/blocs.dart';
-import 'app/data/data.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -16,14 +15,10 @@ Future<void> main() async {
 
   final repository = await Repository.open(session);
 
-  final DirectoryRepository directoryRepository = 
-    DirectoryRepository(repository: repository);
-
   Bloc.observer = SimpleBlocObserver();
 
   runApp(OuiSyncApp(
       session: session,
-      repository: repository,
-      directoryRepository: directoryRepository,
+      repository: repository
     ));
 }


### PR DESCRIPTION
The navigation bloc now loads the destination contents. This way, only build function is used (NavigationBloc) instead of two (NavigationBloc + DirectoryBloc).

Code refactory, redundant code removed.