### PR TITLE
Android share intent fix

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -27,15 +27,6 @@
               android:name="io.flutter.embedding.android.NormalTheme"
               android:resource="@style/NormalTheme"
               />
-            <!-- Displays an Android View that continues showing the launch screen
-                 Drawable until Flutter paints its first frame, then this splash
-                 screen fades out. A splash screen is useful to avoid any visual
-                 gap between the end of Android's launch screen and the painting of
-                 Flutter's first frame. -->
-            <meta-data
-              android:name="io.flutter.embedding.android.SplashScreenDrawable"
-              android:resource="@drawable/launch_background"
-              />
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -36,29 +36,6 @@
             <intent-filter>
                 <action android:name="android.intent.action.SEND" />
                 <category android:name="android.intent.category.DEFAULT" />
-                <data android:mimeType="image/*" />
-            </intent-filter>
-
-            <intent-filter>
-                <action android:name="android.intent.action.SEND_MULTIPLE" />
-                <category android:name="android.intent.category.DEFAULT" />
-                <data android:mimeType="image/*" />
-            </intent-filter>
-
-            <intent-filter>
-                <action android:name="android.intent.action.SEND" />
-                <category android:name="android.intent.category.DEFAULT" />
-                <data android:mimeType="video/*" />
-            </intent-filter>
-            <intent-filter>
-                <action android:name="android.intent.action.SEND_MULTIPLE" />
-                <category android:name="android.intent.category.DEFAULT" />
-                <data android:mimeType="video/*" />
-            </intent-filter>
-
-            <intent-filter>
-                <action android:name="android.intent.action.SEND" />
-                <category android:name="android.intent.category.DEFAULT" />
                 <data android:mimeType="*/*" />
             </intent-filter>
             <intent-filter>

--- a/lib/app/bloc/directory/directory_bloc.dart
+++ b/lib/app/bloc/directory/directory_bloc.dart
@@ -62,7 +62,7 @@ class DirectoryBloc extends Bloc<DirectoryEvent, DirectoryState> {
     if (event is MoveEntry) {
       yield DirectoryLoadInProgress();
 
-      yield await moveEntry(event.repository, event.origin, event.destination, event.entryPath, event.newDestinationPath, event.navigate);
+      yield await moveEntry(event.repository, event.origin, event.destination, event.entryPath, event.newDestinationPath);
     }
 
     if (event is DeleteFile) {
@@ -193,7 +193,7 @@ class DirectoryBloc extends Bloc<DirectoryEvent, DirectoryState> {
     return DirectoryLoadSuccess(path: filePath, contents: readFileResult.result, action: action);
   }
 
-  Future<DirectoryState> moveEntry(Repository repository, String origin, String destination, String entryPath, String newDestinationPath, navigate) async {
+  Future<DirectoryState> moveEntry(Repository repository, String origin, String destination, String entryPath, String newDestinationPath) async {
     try {
       final moveEntryResult = await directoryRepository.moveEntry(repository, entryPath, newDestinationPath);
       if (moveEntryResult.errorMessage.isNotEmpty) {
@@ -205,9 +205,7 @@ class DirectoryBloc extends Bloc<DirectoryEvent, DirectoryState> {
       return DirectoryLoadFailure();
     }
 
-    return navigate
-    ? await navigateTo(repository, Navigation.content, origin, destination)
-    : await getFolderContents(repository, origin);
+    return await getFolderContents(repository, destination);
   }
 
   Future<DirectoryState> deleteFile(Repository repository, String filePath, String parentPath) async {

--- a/lib/app/bloc/directory/directory_event.dart
+++ b/lib/app/bloc/directory/directory_event.dart
@@ -159,8 +159,7 @@ class MoveEntry extends DirectoryEvent {
     required this.origin,
     required this.destination,
     required this.entryPath,
-    required this.newDestinationPath,
-    this.navigate = false
+    required this.newDestinationPath
   }) :
   assert (origin != ''),
   assert (destination != ''),
@@ -172,7 +171,6 @@ class MoveEntry extends DirectoryEvent {
   final String destination;
   final String entryPath;
   final String newDestinationPath;
-  final bool navigate;
 
   @override
   List<Object> get props => [
@@ -180,8 +178,7 @@ class MoveEntry extends DirectoryEvent {
     origin,
     destination,
     entryPath,
-    newDestinationPath,
-    navigate
+    newDestinationPath
   ];
 
 }

--- a/lib/app/bloc/route/route_bloc.dart
+++ b/lib/app/bloc/route/route_bloc.dart
@@ -3,10 +3,8 @@ import 'dart:async';
 import 'package:bloc/bloc.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
-import '../../utils/actions.dart';
 import '../../utils/utils.dart';
 
 part 'route_event.dart';

--- a/lib/app/custom_widgets/bars/navigation_bar.dart
+++ b/lib/app/custom_widgets/bars/navigation_bar.dart
@@ -43,7 +43,7 @@ class _CustomNavigationBarState extends State<CustomNavigationBar> with TickerPr
     return Column(
       children: [
         _repositoriesBar(),
-        _routeBar(route),
+        Fields.routeBar(route: route),
       ],
     );
   }
@@ -85,35 +85,6 @@ class _CustomNavigationBarState extends State<CustomNavigationBar> with TickerPr
         Icons.share_outlined,
         size: 40.0,
         color: Colors.white,
-      ),
-    );
-  }
-
-  Container _routeBar(route) {
-    return Container(
-      padding: EdgeInsets.all(10.0),
-      decoration: const BoxDecoration(
-        border: Border(
-          bottom: BorderSide(
-            width: 0.0,
-            color: Colors.transparent,
-            style: BorderStyle.solid
-          ),
-        ),
-        color: Colors.white,
-      ),
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Expanded(
-            flex: 1,
-            child: Row(
-              children: [
-                Expanded(child: route),
-              ],
-            )
-          ),
-        ],
       ),
     );
   }

--- a/lib/app/custom_widgets/bars/navigation_bar.dart
+++ b/lib/app/custom_widgets/bars/navigation_bar.dart
@@ -1,14 +1,14 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:ouisync_app/app/utils/utils.dart';
 
 import '../../bloc/blocs.dart';
 import '../../cubit/cubits.dart';
 import '../../pages/pages.dart';
 import '../custom_widgets.dart';
 
-class NavigationBar extends StatefulWidget {
-  const NavigationBar({
+class CustomNavigationBar extends StatefulWidget {
+  const CustomNavigationBar({
     required this.repositoriesCubit,
     required this.synchronizationCubit,
     required this.onRepositorySelect,
@@ -21,10 +21,10 @@ class NavigationBar extends StatefulWidget {
   final ShareRepositoryCallback shareRepositoryOnTap;
 
   @override
-  State<NavigationBar> createState() => _NavigationBarState();
+  State<CustomNavigationBar> createState() => _CustomNavigationBarState();
 }
 
-class _NavigationBarState extends State<NavigationBar> with TickerProviderStateMixin {
+class _CustomNavigationBarState extends State<CustomNavigationBar> with TickerProviderStateMixin {
 
   @override
   Widget build(BuildContext context) {

--- a/lib/app/custom_widgets/bars/repository_picker.dart
+++ b/lib/app/custom_widgets/bars/repository_picker.dart
@@ -117,7 +117,13 @@ class _RepositoryPickerState extends State<RepositoryPicker> {
       children: [
         _repositoryIcon(iconColor),
         SizedBox(width: 10.0),
-        buildConstrainedText(_repositoryName, size: 20.0, softWrap: false, overflow: TextOverflow.fade, color: iconColor),
+        Fields.constrainedText(
+          _repositoryName,
+          size: 20.0,
+          softWrap: false,
+          textOverflow: TextOverflow.fade,
+          color: iconColor
+        ),
         _syncSection(widget.synchronizationCubit),
         _actionsSection(),
       ],
@@ -143,7 +149,7 @@ class _RepositoryPickerState extends State<RepositoryPicker> {
 
   Widget _actionsSection() {
     return _repository != null
-    ? buildActionIcon(
+    ? Fields.actionIcon(
       icon: Icons.keyboard_arrow_down_outlined,
       onTap: () async { await _showRepositorySelector(_repositoryName); }
     )

--- a/lib/app/custom_widgets/bars/repository_picker.dart
+++ b/lib/app/custom_widgets/bars/repository_picker.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:ouisync_plugin/ouisync_plugin.dart';
 

--- a/lib/app/custom_widgets/bars/search_bar.dart
+++ b/lib/app/custom_widgets/bars/search_bar.dart
@@ -20,7 +20,11 @@ class _SearchBarState extends State<SearchBar> {
               textAlign: TextAlign.center,
             )
           ),
-          buildActionIcon(icon: Icons.search_outlined, onTap: () {}, size: 35.0)
+          Fields.actionIcon(
+            icon: Icons.search_outlined,
+            onTap: () {},
+            size: 35.0
+          )
         ]
       )
     );

--- a/lib/app/custom_widgets/dialogs/modal_actions_bottom_sheet.dart
+++ b/lib/app/custom_widgets/dialogs/modal_actions_bottom_sheet.dart
@@ -4,7 +4,6 @@ import 'package:flutter/widgets.dart';
 import 'package:ouisync_plugin/ouisync_plugin.dart';
 
 import '../../bloc/blocs.dart';
-import '../../bloc/directory/directory_bloc.dart';
 import '../../utils/utils.dart';
 import '../custom_widgets.dart';
 

--- a/lib/app/custom_widgets/dialogs/modal_actions_bottom_sheet.dart
+++ b/lib/app/custom_widgets/dialogs/modal_actions_bottom_sheet.dart
@@ -32,7 +32,7 @@ class DirectoryActions extends StatelessWidget {
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          buildHandle(context),
+          Fields.bottomSheetHandle(context),
           _folderDetails(this.context, this.bloc, this.repository, this.parent),
         ],
       ),
@@ -47,7 +47,7 @@ class DirectoryActions extends StatelessWidget {
         mainAxisSize: MainAxisSize.max,
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          buildTitle('Add Folders/Files'),
+          Fields.bottomSheetTitle('Add Folders/Files'),
           Row(
             mainAxisAlignment: MainAxisAlignment.spaceEvenly,
             children: [

--- a/lib/app/custom_widgets/dialogs/modal_add_repo_token_dialog.dart
+++ b/lib/app/custom_widgets/dialogs/modal_add_repo_token_dialog.dart
@@ -65,50 +65,50 @@ class _AddRepositoryWithTokenState extends State<AddRepositoryWithToken> {
           SizedBox(height: 20.0,),
           _buildRepositoryNameField(context),
           _buildSuggestionSection(),
-          buildActionsSection(context, _actions(context)),
+          Fields.actionsSection(
+            context,
+            buttons: _actions(context)
+          ),
         ]
       )
     );
   }
 
-  Widget _buildTokenField(BuildContext context) {
-    return buildEntry(
-          context: context,
-          label: 'Repository token: ',
-          hint: 'Paste the token here',
-          onSaved: (value) {},
-          validator: _repositoryTokenValidator,
-          autofocus: true,
-          onChanged: _onTokenChanged
-        );
-  }
-
-  Widget _buildRepositoryNameField(BuildContext context) {
-    return buildEntry(
-          context: context,
-          textEditingController: _textEditingController,
-          label: 'Repository name: ',
-          hint: 'Give the repo a name',
-          onSaved: (value) => _onSaved(widget.cubit, value),
-          validator: formNameValidator,
-          autovalidateMode: AutovalidateMode.disabled
-        );
-  }
-
-  Visibility _buildSuggestionSection() {
-    return Visibility(
-      visible: _showSuggestedName,
-      child: GestureDetector(
-        onTap: () => _updateTokenEntryController(_suggestedName),
-        child: buildConstrainedText(
-          'Suggested: $_repoName\n(tap for using this name)',
-          size: 15.0,
-          fontWeight: FontWeight.normal,
-          color: Colors.black54
-        ),
-      )
+  Widget _buildTokenField(BuildContext context) =>
+    Fields.formTextField(
+      context: context,
+      label: 'Repository token: ',
+      hint: 'Paste the token here',
+      onSaved: (value) {},
+      validator: _repositoryTokenValidator,
+      autofocus: true,
+      onChanged: _onTokenChanged
     );
-  }
+
+  Widget _buildRepositoryNameField(BuildContext context) =>
+    Fields.formTextField(
+      context: context,
+      textEditingController: _textEditingController,
+      label: 'Repository name: ',
+      hint: 'Give the repo a name',
+      onSaved: (value) => _onSaved(widget.cubit, value),
+      validator: formNameValidator,
+      autovalidateMode: AutovalidateMode.disabled
+    );
+
+  Visibility _buildSuggestionSection() =>
+  Visibility(
+    visible: _showSuggestedName,
+    child: GestureDetector(
+      onTap: () => _updateTokenEntryController(_suggestedName),
+      child: Fields.constrainedText(
+        'Suggested: $_repoName\n(tap for using this name)',
+        size: 15.0,
+        fontWeight: FontWeight.normal,
+        color: Colors.black54
+      ),
+    )
+  );
 
   _updateTokenEntryController(String? value) {
     _textEditingController.text = value ?? '';

--- a/lib/app/custom_widgets/dialogs/modal_file_detail_bottom_sheet.dart
+++ b/lib/app/custom_widgets/dialogs/modal_file_detail_bottom_sheet.dart
@@ -48,7 +48,7 @@ class _FileDetailState extends State<FileDetail> {
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          buildHandle(context),
+          Fields.bottomSheetHandle(context),
           _fileDetails(context),
         ],
       ),
@@ -63,7 +63,7 @@ class _FileDetailState extends State<FileDetail> {
         mainAxisSize: MainAxisSize.max,
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          buildTitle('File Details'),
+          Fields.bottomSheetTitle('File Details'),
           _buildPreviewButton(),
           _buildShareButton(),
           _buildMoveFolderButton(
@@ -80,26 +80,26 @@ class _FileDetailState extends State<FileDetail> {
             indent: 20.0,
             endIndent: 20.0,
           ),
-          buildIconLabel(
-            Icons.info_rounded,
-            'Information',
+          Fields.iconText(
+            icon: Icons.info_rounded,
+            text: 'Information',
             iconSize: 40.0,
-            infoSize: 24.0,
-            labelPadding: EdgeInsets.only(bottom: 30.0)
+            textSize: 24.0,
+            padding: EdgeInsets.only(bottom: 30.0)
           ),
-          buildInfoLabel(
-            'Name: ',
-            widget.name
+          Fields.labeledText(
+            label: 'Name: ',
+            text: widget.name
           ),
-          buildInfoLabel(
-            'Location: ', 
-            widget.path
+          Fields.labeledText(
+            label: 'Location: ', 
+            text: widget.path
             .replaceAll(widget.name, '')
             .trimRight(),
           ),
-          buildInfoLabel(
-            'Size: ',
-            formattSize(widget.size, units: true)
+          Fields.labeledText(
+            label: 'Size: ',
+            text: formattSize(widget.size, units: true)
           ),
         ],
       ),
@@ -109,12 +109,12 @@ class _FileDetailState extends State<FileDetail> {
   GestureDetector _buildPreviewButton() {
     return GestureDetector(
           onTap: () async => await NativeChannels.previewOuiSyncFile(widget.path, widget.size),
-          child: buildIconLabel(
-            Icons.preview_rounded,
-            'Preview',
+          child: Fields.iconText(
+            icon: Icons.preview_rounded,
+            text: 'Preview',
             iconSize: 40.0,
-            infoSize: 18.0,
-            labelPadding: EdgeInsets.only(bottom: 30.0)
+            textSize: 18.0,
+            padding: EdgeInsets.only(bottom: 30.0)
           ),
         );
   }
@@ -122,12 +122,12 @@ class _FileDetailState extends State<FileDetail> {
   GestureDetector _buildShareButton() {
     return GestureDetector(
           onTap: () async => await NativeChannels.shareOuiSyncFile(widget.path, widget.size),
-          child: buildIconLabel(
-            Icons.share_rounded,
-            'Share',
+          child: Fields.iconText(
+            icon: Icons.share_rounded,
+            text: 'Share',
             iconSize: 40.0,
-            infoSize: 18.0,
-            labelPadding: EdgeInsets.only(bottom: 30.0)
+            textSize: 18.0,
+            padding: EdgeInsets.only(bottom: 30.0)
           ),
         );
   }
@@ -147,12 +147,12 @@ class _FileDetailState extends State<FileDetail> {
         moveEntryCallback,
         bottomSheetControllerCallback
       ),
-      child: buildIconLabel(
-        Icons.drive_file_move_outlined,
-        'Move',
+      child: Fields.iconText(
+        icon: Icons.drive_file_move_outlined,
+        text: 'Move',
         iconSize: 40.0,
-        infoSize: 18.0,
-        labelPadding: EdgeInsets.only(bottom: 30.0)
+        textSize: 18.0,
+        padding: EdgeInsets.only(bottom: 30.0)
       ),
     );
   }
@@ -190,12 +190,12 @@ class _FileDetailState extends State<FileDetail> {
   GestureDetector _buildDeleteButton() {
     return GestureDetector(
       onTap: () async => {},
-      child: buildIconLabel(
-        Icons.delete_outlined,
-        'Delete',
+      child: Fields.iconText(
+        icon: Icons.delete_outlined,
+        text: 'Delete',
         iconSize: 40.0,
-        infoSize: 18.0,
-        labelPadding: EdgeInsets.only(bottom: 30.0)
+        textSize: 18.0,
+        padding: EdgeInsets.only(bottom: 30.0)
       ),
     );
   }

--- a/lib/app/custom_widgets/dialogs/modal_folder_creation_dialog.dart
+++ b/lib/app/custom_widgets/dialogs/modal_folder_creation_dialog.dart
@@ -53,15 +53,21 @@ class FolderCreation extends StatelessWidget {
         mainAxisSize: MainAxisSize.max,
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          buildEntry(
+          Fields.formTextField(
             context: context,
             label: 'Create a new folder: ',
             hint: 'Folder name',
             onSaved: (value) => _onSaved(bloc, value),
             validator: formNameValidator
           ),
-          buildInfoLabel('Location: ', this.path),
-          buildActionsSection(context, _actions(context)),
+          Fields.labeledText(
+            label: 'Location: ',
+            text: this.path
+          ),
+          Fields.actionsSection(
+            context,
+            buttons: _actions(context)
+          ),
         ]
       )
     );

--- a/lib/app/custom_widgets/dialogs/modal_folder_creation_dialog.dart
+++ b/lib/app/custom_widgets/dialogs/modal_folder_creation_dialog.dart
@@ -58,7 +58,8 @@ class FolderCreation extends StatelessWidget {
             label: 'Create a new folder: ',
             hint: 'Folder name',
             onSaved: (value) => _onSaved(bloc, value),
-            validator: formNameValidator
+            validator: formNameValidator,
+            autofocus: true
           ),
           Fields.labeledText(
             label: 'Location: ',

--- a/lib/app/custom_widgets/dialogs/modal_folder_creation_dialog.dart
+++ b/lib/app/custom_widgets/dialogs/modal_folder_creation_dialog.dart
@@ -54,6 +54,7 @@ class FolderCreation extends StatelessWidget {
         children: [
           Fields.formTextField(
             context: context,
+            icon: const Icon(Icons.folder),
             label: 'Create a new folder: ',
             hint: 'Folder name',
             onSaved: (value) => _onSaved(bloc, value),

--- a/lib/app/custom_widgets/dialogs/modal_folder_creation_dialog.dart
+++ b/lib/app/custom_widgets/dialogs/modal_folder_creation_dialog.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
 import 'package:ouisync_plugin/ouisync_plugin.dart';
 
 import '../../bloc/blocs.dart';

--- a/lib/app/custom_widgets/dialogs/modal_folder_detail_bottom_sheet.dart
+++ b/lib/app/custom_widgets/dialogs/modal_folder_detail_bottom_sheet.dart
@@ -49,7 +49,7 @@ class _FolderDetailState extends State<FolderDetail> {
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          buildHandle(context),
+          Fields.bottomSheetHandle(context),
           _folderDetails(context),
         ],
       ),
@@ -64,7 +64,7 @@ class _FolderDetailState extends State<FolderDetail> {
         mainAxisSize: MainAxisSize.max,
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          buildTitle(widget.name),
+          Fields.bottomSheetTitle(widget.name),
           GestureDetector(
             onTap: () => delete(
               widget.context,
@@ -73,12 +73,12 @@ class _FolderDetailState extends State<FolderDetail> {
               widget.parent,
               widget.path
             ),
-            child: buildIconLabel(
-              Icons.delete_outlined,
-              'Delete',
+            child: Fields.iconText(
+              icon: Icons.delete_outlined,
+              text: 'Delete',
               iconSize: 40.0,
-              infoSize: 18.0,
-              labelPadding: EdgeInsets.only(bottom: 30.0)
+              textSize: 18.0,
+              padding: EdgeInsets.only(bottom: 30.0)
             )
           ),
           _buildMoveFolderButton(
@@ -94,12 +94,12 @@ class _FolderDetailState extends State<FolderDetail> {
             indent: 20.0,
             endIndent: 20.0,
           ),
-          buildIconLabel(
-            Icons.info_rounded,
-            'Information',
+          Fields.iconText(
+            icon: Icons.info_rounded,
+            text: 'Information',
             iconSize: 40.0,
-            infoSize: 24.0,
-            labelPadding: EdgeInsets.only(bottom: 30.0)
+            textSize: 24.0,
+            padding: EdgeInsets.only(bottom: 30.0)
           ),
           syncStatus(),
         ]
@@ -230,12 +230,12 @@ class _FolderDetailState extends State<FolderDetail> {
         moveEntryCallback,
         bottomSheetControllerCallback
       ),
-      child: buildIconLabel(
-        Icons.drive_file_move_outlined,
-        'Move',
+      child: Fields.iconText(
+        icon: Icons.drive_file_move_outlined,
+        text: 'Move',
         iconSize: 40.0,
-        infoSize: 18.0,
-        labelPadding: EdgeInsets.only(bottom: 30.0)
+        textSize: 18.0,
+        padding: EdgeInsets.only(bottom: 30.0)
       ),
     );
   }
@@ -274,7 +274,7 @@ class _FolderDetailState extends State<FolderDetail> {
     return Row(
       mainAxisAlignment: MainAxisAlignment.spaceAround,
       children: [
-        buildIdLabel('Sync Status:'),
+        Fields.idLabel('Sync Status:'),
         Container(
           height: 60.0,
           alignment: Alignment.center,

--- a/lib/app/custom_widgets/dialogs/modal_repo_creation_dialog.dart
+++ b/lib/app/custom_widgets/dialogs/modal_repo_creation_dialog.dart
@@ -48,14 +48,16 @@ class RepositoryCreation extends StatelessWidget {
         mainAxisSize: MainAxisSize.max,
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          buildEntry(
+          Fields.formTextField(
             context: context,
             label: 'Create a new repository: ',
             hint: 'Respository name',
             onSaved: (value) => _onSaved(cubit, value),
             validator: formNameValidator
           ),
-          buildActionsSection(context, _actions(context)),
+          Fields.actionsSection(
+            context,
+            buttons: _actions(context)),
         ]
       )
     );

--- a/lib/app/custom_widgets/dialogs/modal_repo_creation_dialog.dart
+++ b/lib/app/custom_widgets/dialogs/modal_repo_creation_dialog.dart
@@ -53,7 +53,8 @@ class RepositoryCreation extends StatelessWidget {
             label: 'Create a new repository: ',
             hint: 'Respository name',
             onSaved: (value) => _onSaved(cubit, value),
-            validator: formNameValidator
+            validator: formNameValidator,
+            autofocus: true
           ),
           Fields.actionsSection(
             context,

--- a/lib/app/custom_widgets/dialogs/modal_repository_list_bottom_sheet.dart
+++ b/lib/app/custom_widgets/dialogs/modal_repository_list_bottom_sheet.dart
@@ -34,7 +34,7 @@ class RepositoryList extends StatelessWidget {
             child: Column(
               mainAxisSize: MainAxisSize.min,
               children: [
-                buildHandle(context),
+                Fields.bottomSheetHandle(context),
                 _folderDetails(context, snapshot.data as List<String>),
               ],
             ),
@@ -54,30 +54,30 @@ class RepositoryList extends StatelessWidget {
         mainAxisSize: MainAxisSize.max,
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          buildTitle('Your Repositories'),
+          Fields.bottomSheetTitle('Your Repositories'),
           _buildRepositoryItem(localRepositories, current),
           SizedBox(height: 50.0,),
           GestureDetector(
             onTap: () => createRepoDialog(this.cubit),
-            child: buildIconLabel(
-              Icons.add_circle_outline_rounded,
-              'Create a new repository',
+            child: Fields.iconText(
+              icon: Icons.add_circle_outline_rounded,
+              text: 'Create a new repository',
               iconSize: 40.0,
               iconColor: Colors.black,
-              infoSize: 25.0,
-              labelPadding: EdgeInsets.only(bottom: 10.0)
+              textSize: 25.0,
+              padding: EdgeInsets.only(bottom: 10.0)
             )
           ),
           SizedBox(height: 20.0,),
           GestureDetector(
             onTap: () => addRepoWithTokenDialog(this.cubit),
-            child: buildIconLabel(
-              Icons.insert_link_rounded,
-              'Add a repository with token',
+            child: Fields.iconText(
+              icon: Icons.insert_link_rounded,
+              text: 'Add a repository with token',
               iconSize: 40.0,
               iconColor: Colors.black,
-              infoSize: 25.0,
-              labelPadding: EdgeInsets.only(bottom: 10.0)
+              textSize: 25.0,
+              padding: EdgeInsets.only(bottom: 10.0)
             )
           ),
         ]

--- a/lib/app/custom_widgets/dialogs/modal_share_repository_bottom_sheet.dart
+++ b/lib/app/custom_widgets/dialogs/modal_share_repository_bottom_sheet.dart
@@ -24,7 +24,7 @@ class ShareRepository extends StatelessWidget {
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          buildHandle(context),
+          Fields.bottomSheetHandle(context),
           _shareCodeDetails(context, this.repositoryName, this.token),
         ],
       ),
@@ -39,8 +39,12 @@ class ShareRepository extends StatelessWidget {
         mainAxisSize: MainAxisSize.max,
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          buildTitle('Share $repositoryName'),
-          buildIconLabel(Icons.supervisor_account_rounded, 'Share this with your peer', iconSize: 40.0),
+          Fields.bottomSheetTitle('Share $repositoryName'),
+          Fields.iconText(
+            icon: Icons.supervisor_account_rounded,
+            text: 'Share this with your peer',
+            iconSize: 40.0
+          ),
           _buildShareBox(token)
         ]
       )
@@ -60,7 +64,13 @@ class ShareRepository extends StatelessWidget {
     ),
     child: Row(
       children: [
-        buildConstrainedText(token, size: 20.0, softWrap: false, overflow: TextOverflow.ellipsis, color: Colors.black),
+        Fields.constrainedText(
+          token,
+          size: 20.0,
+          softWrap: false,
+          textOverflow: TextOverflow.ellipsis,
+          color: Colors.black
+        ),
         _copyTokenAction(token),
         _shareTokenAction(token),
       ],

--- a/lib/app/custom_widgets/dialogs/move_entry_bottom_sheet.dart
+++ b/lib/app/custom_widgets/dialogs/move_entry_bottom_sheet.dart
@@ -4,7 +4,6 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:ouisync_plugin/ouisync_plugin.dart';
 
 import '../../bloc/blocs.dart';
-import '../../bloc/directory/directory_bloc.dart';
 import '../../pages/pages.dart';
 import '../../utils/utils.dart';
 

--- a/lib/app/custom_widgets/dialogs/move_entry_bottom_sheet.dart
+++ b/lib/app/custom_widgets/dialogs/move_entry_bottom_sheet.dart
@@ -47,7 +47,7 @@ class MoveEntryDialog extends StatelessWidget {
         children: [
           _movingActionTitle(),
           SizedBox(width: 10.0,),
-          buildConstrainedText(
+          Fields.constrainedText(
             'from: ${extractParentFromPath(path)}',
             size: 16.0,
             fontWeight: FontWeight.w800
@@ -66,7 +66,11 @@ class MoveEntryDialog extends StatelessWidget {
               size: 40.0,
             ),
             SizedBox(width: 10.0,),
-            buildConstrainedText('${removeParentFromPath(path)}', size: 24.0, fontWeight: FontWeight.w800),
+            Fields.constrainedText(
+              '${removeParentFromPath(path)}',
+              size: 24.0,
+              fontWeight: FontWeight.w800
+            ),
           ],
         );
   }
@@ -83,7 +87,10 @@ class MoveEntryDialog extends StatelessWidget {
           }
         }
 
-        return buildActionsSection(context, _actions(context, allowAction), padding: EdgeInsets.only(top: 0.0));
+        return Fields.actionsSection(context,
+          buttons: _actions(context, allowAction),
+          padding: EdgeInsets.only(top: 0.0)
+        );
       }
     );
   }

--- a/lib/app/custom_widgets/items/file_description.dart
+++ b/lib/app/custom_widgets/items/file_description.dart
@@ -4,7 +4,7 @@ import 'package:ouisync_plugin/ouisync_plugin.dart';
 import '../../models/models.dart';
 import '../../utils/utils.dart';
 
-class FileDescription extends StatefulWidget {
+class FileDescription extends StatelessWidget {
   const FileDescription({
     required this.repository,
     required this.fileData,
@@ -14,59 +14,50 @@ class FileDescription extends StatefulWidget {
   final BaseItem fileData;
 
   @override
-  State<StatefulWidget> createState() => _FileDescription();
-}
-
-class _FileDescription extends State<FileDescription> {
-  @override
   Widget build(BuildContext context) {
     return Container(
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children:  [
           Text(
-            widget.fileData.name,
+            fileData.name,
             style: const TextStyle(
               fontWeight: FontWeight.w500,
               fontSize: 16.0,
             ),
           ),
           const Padding(padding: EdgeInsets.symmetric(vertical: 2.0)),
-          size(widget.fileData.path)
+          size(repository, fileData.path)
         ],
       ),
     );
   }
 
-  Widget size(path) {
-    return FutureBuilder<String>(
-      future: getFileSize(path),
-      builder: (context, AsyncSnapshot<String> snapshot) {
+  Widget size(repository, path) {
+    return FutureBuilder<int>(
+      initialData: 0,
+      future: EntryInfo(repository).fileLength(path),
+      builder: (context, AsyncSnapshot<int> snapshot) {
         if (snapshot.hasError) {
           return Text(
-            '?',
+            '? B',
             style: const TextStyle(fontSize: 14.0),
           );
         }
 
         if (snapshot.hasData) {
           return Text(
-            snapshot.data!,
+            formattSize(snapshot.data ?? 0, units: true),
             style: const TextStyle(fontSize: 14.0),
           );
-        } else {
-          return CircularProgressIndicator();
         }
+
+        return Container(
+          height: 15.0,
+          width: 15.0,
+          child: CircularProgressIndicator(strokeWidth: 2.0,)
+        );
       }
     );
   }
-
-  Future<String> getFileSize(path) async {
-    // TODO: Check if this delay is still needed (This delay was here because without it, the library would hang) 
-    // await Future.delayed(Duration(seconds: 2));
-
-    final length = await EntryInfo(widget.repository).fileLength(path);
-    return formattSize(length, units: true);
-  }
-
 }

--- a/lib/app/custom_widgets/items/file_description.dart
+++ b/lib/app/custom_widgets/items/file_description.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
 import 'package:ouisync_plugin/ouisync_plugin.dart';
 
 import '../../models/models.dart';

--- a/lib/app/custom_widgets/items/list_item.dart
+++ b/lib/app/custom_widgets/items/list_item.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
 import 'package:ouisync_plugin/ouisync_plugin.dart';
 
 import '../../models/models.dart';

--- a/lib/app/data/repositories/directory_repository.dart
+++ b/lib/app/data/repositories/directory_repository.dart
@@ -1,4 +1,4 @@
-import 'package:chunked_stream/chunked_stream.dart';
+import 'package:async/async.dart';
 import 'package:ouisync_plugin/ouisync_plugin.dart';
 
 import '../../models/models.dart';
@@ -44,13 +44,14 @@ class DirectoryRepository {
     BasicResult writeFileResult;
     String error = '';
 
-    int offset = 0;
+    final streamReader = ChunkedStreamReader(fileStream);
+    
     final file = await _openFile(repository, filePath);
-
+    int offset = 0;
+    
     try {
-      final streamReader = ChunkedStreamIterator(fileStream);
       while (true) {
-        final buffer = await streamReader.read(Constants.bufferSize);
+        final buffer = await streamReader.readChunk(Constants.bufferSize);
         print('Buffer size: ${buffer.length} - offset: $offset');
 
         if (buffer.isEmpty) {
@@ -65,6 +66,7 @@ class DirectoryRepository {
       print('Exception writing the fie $filePath:\n${e.toString()}');
       error = 'Writing to the file $filePath failed';
     } finally {
+      streamReader.cancel();
       file.close();
     }
 

--- a/lib/app/models/item/folder_item.dart
+++ b/lib/app/models/item/folder_item.dart
@@ -1,6 +1,5 @@
 import 'package:equatable/equatable.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
 
 import '../models.dart';
 

--- a/lib/app/pages/main_page.dart
+++ b/lib/app/pages/main_page.dart
@@ -136,7 +136,6 @@ class _MainPageState extends State<MainPage>
   }
 
   navigateToPath({type, origin, destination, withProgress = false}) {
-    print('navigateToPath destination: $destination');
     BlocProvider.of<DirectoryBloc>(context)
     .add(
       NavigateTo(
@@ -288,7 +287,15 @@ class _MainPageState extends State<MainPage>
     },
     builder: (context, state) {
       if (state is DirectoryInitial) {
-        return Center(child: Text('Loading contents...'));
+        return Center(
+          child: Text(
+            Strings.messageLoadingContents,
+            style: TextStyle(
+              fontSize: 23.0,
+              fontWeight: FontWeight.bold
+            )
+          )
+        );
       }
 
       if (state is DirectoryLoadInProgress) {

--- a/lib/app/pages/main_page.dart
+++ b/lib/app/pages/main_page.dart
@@ -5,7 +5,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:ouisync_plugin/ouisync_plugin.dart';
 import 'package:receive_sharing_intent/receive_sharing_intent.dart';
-import 'package:styled_text/icon_style.dart';
 import 'package:styled_text/styled_text.dart';
 
 import '../bloc/blocs.dart';

--- a/lib/app/pages/main_page.dart
+++ b/lib/app/pages/main_page.dart
@@ -200,7 +200,7 @@ class _MainPageState extends State<MainPage>
     actions: [
       Padding(
         padding: EdgeInsets.only(right: 10.0),
-        child: buildActionIcon(
+        child: Fields.actionIcon(
           icon: Icons.settings_outlined,
           onTap: () async {
             bool dhtStatus = false;
@@ -214,7 +214,8 @@ class _MainPageState extends State<MainPage>
               dhtStatus
             );
           },
-          size: 35.0
+          size: 35.0,
+          color: Theme.of(context).colorScheme.surface
         ),
       )
     ],
@@ -447,17 +448,13 @@ class _MainPageState extends State<MainPage>
       SizedBox(height: 20.0),
       Align(
         alignment: Alignment.center,
-        child: StyledText(
-          text: Strings.messageCreateNewRepoStyled,
-          style: TextStyle(
-            fontSize: 16.0,
-            fontWeight: FontWeight.normal
-          ),
-          styles: {
-            'bold': TextStyle(fontWeight: FontWeight.bold),
-            'arrow_down': IconStyle(Icons.south),
-          },
-        ),
+        child: Fields.inPageSecondaryMessage(
+          Strings.messageCreateNewRepoStyled,
+          tags: {
+            'bold': StyledTextTag(style: TextStyle(fontWeight: FontWeight.bold)),
+            'arrow_down': StyledTextIconTag(Icons.south),
+          }
+        )
       ),
       SizedBox(height: 20.0),
       ElevatedButton(
@@ -493,16 +490,16 @@ class _MainPageState extends State<MainPage>
           SizedBox(height: 20.0),
           Align(
             alignment: Alignment.center,
-            child: StyledText(
-              text: Strings.messageCreateAddNewItemStyled,
-              style: TextStyle(
-                fontSize: 16.0,
-                fontWeight: FontWeight.normal
-              ),
-              styles: {
-                'bold': TextStyle(fontWeight: FontWeight.bold),
-                'arrow_down': IconStyle(Icons.south),
-              },
+            child: Fields.inPageSecondaryMessage(
+              Strings.messageCreateAddNewItemStyled,
+              tags: {
+                'bold': StyledTextTag(style: TextStyle(fontWeight: FontWeight.bold)),
+                'add_circle': StyledTextIconTag(
+                  Icons.add_circle,
+                  size: 34.0,
+                  color: Theme.of(context).primaryColor
+                ),
+              }
             ),
           ),
         ],

--- a/lib/app/pages/main_page.dart
+++ b/lib/app/pages/main_page.dart
@@ -3,9 +3,9 @@ import 'dart:async';
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:fluttertoast/fluttertoast.dart';
 import 'package:ouisync_plugin/ouisync_plugin.dart';
 import 'package:receive_sharing_intent/receive_sharing_intent.dart';
-import 'package:styled_text/styled_text.dart';
 
 import '../bloc/blocs.dart';
 import '../cubit/cubits.dart';
@@ -21,14 +21,16 @@ typedef MoveEntryBottomSheetControllerCallback = void Function(PersistentBottomS
 
 class MainPage extends StatefulWidget {
   const MainPage({
-    required this.defaultRepository,
+    required this.session,
+    required this.repositoriesLocation,
     required this.defaultRepositoryName,
-    required this.title,
+    required this.intentStream
   });
 
-  final Repository? defaultRepository;
+  final Session session;
+  final String repositoriesLocation;
   final String defaultRepositoryName;
-  final String title;
+  final Stream<List<SharedMediaFile>> intentStream;
   
   @override
   State<StatefulWidget> createState() => _MainPageState(); 
@@ -37,474 +39,581 @@ class MainPage extends StatefulWidget {
 class _MainPageState extends State<MainPage>
   with TickerProviderStateMixin {
 
-  Repository? _repository;
-  Subscription? _repositorySubscription;
+    List<SharedMediaFile> _intentPayload = <SharedMediaFile>[];
 
-  late Widget _mainState = Container();
+    Repository? _repository;
+    Subscription? _repositorySubscription;
+
+    String _repositoryName = '';
+    String _currentFolder = Strings.rootPath; // Initial value: /
+  
+    List<BaseItem> _folderContents = <BaseItem>[];
     
-  late StreamSubscription _intentDataStreamSubscription;
-  late final SynchronizationCubit _syncingCubit;
+    SynchronizationCubit? _syncingCubit;
+    
+    final _scaffoldKey = GlobalKey<ScaffoldState>();
 
-  String _repositoryName = '';
+    String _pathEntryToMove = '';
+    PersistentBottomSheetController? _persistentBottomSheetController;
 
-  String _currentFolder = Strings.rootPath; // Initial value: /
-  List<BaseItem> _folderContents = <BaseItem>[];
+    Widget _mainState = Container();
 
-  final _scaffoldKey = GlobalKey<ScaffoldState>();
+    @override
+    void initState() {
+      super.initState();
+      
+      widget.intentStream
+      .listen((listOfMedia) {
+        _intentPayload = listOfMedia;
+      });
 
-  PersistentBottomSheetController? _persistentBottomSheetController;
-  String _pathEntryToMove = '';
+      _syncingCubit = BlocProvider.of<SynchronizationCubit>(context);
 
-  @override
-  void initState() {
-    super.initState();
+      initOuiSync(
+        widget.session,
+        widget.defaultRepositoryName,
+        widget.repositoriesLocation
+      )
+      .then((repository) {
+        NativeChannels.init(repository: repository);
+        initMainPageLayout(repository, widget.defaultRepositoryName);
 
-    _syncingCubit = BlocProvider.of<SynchronizationCubit>(context);
+        if (_intentPayload.isEmpty) {
+          return;
+        }
 
-    handleIncomingShareIntent();
-    initRepository();
-  }
+        if (repository == null) {
+          Fluttertoast
+          .showToast(msg: Strings.messageNoRepo, toastLength: Toast.LENGTH_LONG);
 
-  @override
-  void dispose() {
-    super.dispose();
+          return;
+        }
 
-    _repositorySubscription!.cancel();
-    _intentDataStreamSubscription.cancel();
-  }
-
-  void handleIncomingShareIntent() {
-    // For sharing files coming from outside the app while the app is in the memory
-    _intentDataStreamSubscription =
-        ReceiveSharingIntent.getMediaStream().listen((List<SharedMediaFile> value) {
-        print("Shared:" + (value.map((f)=> f.path).join(",")));  
-        _processIntent(value);
-    }, onError: (err) {
-      print("getIntentDataStream error: $err");
-    });
-
-    // For sharing files coming from outside the app while the app is closed
-    ReceiveSharingIntent.getInitialMedia().then((List<SharedMediaFile> value) {
-      print("Shared:" + (value.map((f)=> f.path).join(",")));  
-      _processIntent(value);
-    });
-  }
-
-  Future<void> _processIntent(List<SharedMediaFile> sharedMedia) async {
-    if (sharedMedia.isEmpty) {
-      return;
+        _saveSharedMedia(repository, _currentFolder, _intentPayload);
+      });
     }
 
-    Navigator.push(
-      context,
-      MaterialPageRoute(builder: (context) {
-        return AddSharedFilePage(
-          repository:  _repository!,
-          sharedFileInfo: sharedMedia,
-          directoryBloc: BlocProvider.of<DirectoryBloc>(context),
-          directoryBlocPath: _currentFolder,
+    @override
+    void dispose() {
+      _repositorySubscription?.cancel();
+      _repository?.close();
+  
+      super.dispose();
+    }
+
+    Future<Repository?> initOuiSync(
+      Session session,
+      String defaultRepositoryName,
+      String repositoriesLocation
+    ) async {
+      if (defaultRepositoryName.isEmpty) {
+        return null;
+      }
+
+      print('Default repository: $defaultRepositoryName');
+
+      Repository? repository;
+      try {
+        repository = await Repository
+        .open(
+          session,
+          '$repositoriesLocation/$defaultRepositoryName.db'
         );
-      })
-    );
-  }
+      } catch (e) {
+        print('Exception opening a repository instance: ${e.toString()}');
+      }
 
-  void initRepository() {
-    switchMainState(widget.defaultRepository == null
-    ? _noRepositories()
-    : _repositoryContentBuilder());
+      print('Repository instance opened: (${_repository?.handle ?? 'null'})');
 
-    BlocProvider.of<RepositoriesCubit>(context)
-    .selectRepository(
-      widget.defaultRepository,
-      widget.defaultRepositoryName
-    );
-  }
+      return repository;
+    }
 
-  switchMainState(state) => setState(() { _mainState = state; });
+    void initMainPageLayout(Repository? repository, String repositoryName) {
+      if (repository == null) {
+        switchMainState(newState: _noRepositoriesState());
+      }
 
-  getContents({path, recursive = false, withProgress = false, isSyncing = false}) { 
-    BlocProvider.of<DirectoryBloc>(context)
-    .add(
-      GetContent(
-        repository: _repository!,
+      BlocProvider
+      .of<RepositoriesCubit>(context)
+      .selectRepository(
+        repository,
+        repositoryName
+      );
+    }
+
+    Future<void> _saveSharedMedia(
+      Repository repository,
+      String currentFolder,
+      List<SharedMediaFile> sharedMedia
+    ) async {
+      final routeBloc = BlocProvider.of<RouteBloc>(context);
+      final directoryBloc = BlocProvider.of<DirectoryBloc>(context);
+
+      final navigationBar = CustomNavigationBar(
+        repositoriesCubit: BlocProvider.of<RepositoriesCubit>(context),
+        synchronizationCubit: BlocProvider.of<SynchronizationCubit>(context),
+        onRepositorySelect: switchRepository,
+        shareRepositoryOnTap: shareRepository,
+      );
+
+      Navigator.push(
+        context,
+        MaterialPageRoute(
+          builder: (context) {
+            return BlocProvider.value(
+              value: routeBloc,
+              child: AddSharedFilePage(
+                repository:  repository,
+                listOfSharedMedia: sharedMedia,
+                routeBloc: routeBloc,
+                directoryBloc: directoryBloc,
+                directoryBlocPath: currentFolder,
+                navigationBar: navigationBar
+              )
+            );
+          }
+        )
+      );
+    }
+
+    switchMainState({newState}) => setState(() { _mainState = newState; });
+    updateCurrentFolder({required String path}) => setState(() { _currentFolder = path; });
+
+    getContents({
+      required Repository repository,
+      required String path,
+      bool recursive = false,
+      bool withProgress = false,
+      bool isSyncing = false
+    }) { 
+      BlocProvider
+      .of<DirectoryBloc>(context)
+      .add(GetContent(
+        repository: repository,
         path: path,
         recursive: recursive,
         withProgress: withProgress,
         isSyncing: isSyncing
-      )
-    );
-  }
+      ));
+    }
 
-  navigateToPath({type, origin, destination, withProgress = false}) {
-    BlocProvider.of<DirectoryBloc>(context)
-    .add(
-      NavigateTo(
-        repository: _repository!,
+    navigateToPath({
+      required Repository repository,
+      required Navigation type,
+      required String origin,
+      required String destination,
+      bool withProgress = false
+    }) {
+      BlocProvider
+      .of<DirectoryBloc>(context)
+      .add(NavigateTo(
+        repository: repository,
         type: type,
         origin: origin,
         destination: destination,
         withProgress: withProgress
-      )
-    ); 
-  }
+      )); 
+    }
 
-  updateRoute(destination) {
-    BlocProvider.of<RouteBloc>(context)
-    .add(
-      UpdateRoute(
+    updateRoute({
+      required Repository repository,
+      required String destination
+    }) {
+      BlocProvider
+      .of<RouteBloc>(context)
+      .add(UpdateRoute(
         path: destination,
         action: () { //Back button action, hence we invert the origin and destination values
           final from = destination;
           final backTo = extractParentFromPath(from);
 
-          BlocProvider.of<DirectoryBloc>(context)
-          .add(
-            NavigateTo(
-              repository: _repository!,
-              type: Navigation.content,
-              origin: from,
-              destination: backTo,
-              withProgress: true
-            )
-          );
+          BlocProvider
+          .of<DirectoryBloc>(context)
+          .add(NavigateTo(
+            repository: repository,
+            type: Navigation.content,
+            origin: from,
+            destination: backTo,
+            withProgress: true
+          ));
         }
-      )
-    );
-  }
-
-  Future<void> refreshCurrent() async =>
-    getContents(path: _currentFolder, withProgress: true);
-
-  void subscribeToRepositoryNotifications(repository) async {
-    _repositorySubscription = repository.subscribe(() { 
-      _syncingCubit.syncing();
-      getContents(path: _currentFolder, isSyncing: true);
-    });
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      key: _scaffoldKey,
-      appBar: _getOuiSyncBar(),
-      body: _mainState,
-      floatingActionButton: _getFAB(context),
-    );
-  }
-
-  _getOuiSyncBar() => OuiSyncBar(
-    appBranding: AppBranding(appName: widget.title),
-    centralWidget: Container(), //SearchBar(), |removed until implemented
-    actions: [
-      Padding(
-        padding: EdgeInsets.only(right: 10.0),
-        child: Fields.actionIcon(
-          icon: Icons.settings_outlined,
-          onTap: () async {
-            bool dhtStatus = false;
-            if (_repository != null) {
-              dhtStatus = await _repository!.isDhtEnabled();  
-            }
-            
-            settingsAction(
-              BlocProvider.of<RepositoriesCubit>(context),
-              BlocProvider.of<SynchronizationCubit>(context),
-              dhtStatus
-            );
-          },
-          size: 35.0,
-          color: Theme.of(context).colorScheme.surface
-        ),
-      )
-    ],
-    bottom: NavigationBar(
-      repositoriesCubit: BlocProvider.of<RepositoriesCubit>(context),
-      synchronizationCubit: BlocProvider.of<SynchronizationCubit>(context),
-      onRepositorySelect: switchRepository,
-      shareRepositoryOnTap: shareRepository,
-    ),
-    mode: BarMode.full,
-    toolbarHeight: 200.0,
-    preferredSize: Size.fromHeight(200.0)
-  );
-
-  StatelessWidget _getFAB(BuildContext context) {
-    return _repository != null
-    ? new FloatingActionButton(
-      child: const Icon(Icons.add_rounded),
-      onPressed: () => _showDirectoryActions(
-        context, 
-        BlocProvider.of<DirectoryBloc>(context), 
-        _repository!, 
-        _currentFolder
-      ),
-    )
-    : Container();
-  }
-
-  void switchRepository(repository, name) {
-    if (_repositorySubscription != null) {
-      _repositorySubscription!.cancel();
-      print('Repository subscription ${_repositorySubscription!.handle} closed');
+      ));
     }
 
-    if (_repository != null) {
-      _repository!.close();
-      print('Repository ${_repository!.handle} closed');
-    }
-
-    NativeChannels.setRepository(repository);
-
-    _repository = repository;
-    _repositoryName = name;
-
-    switchMainState(_repositoryContentBuilder());
-
-    navigateToPath(
-      type: Navigation.content,
-      origin: Strings.rootPath,
-      destination: Strings.rootPath,
+    Future<void> refreshCurrent({
+      required Repository repository,
+      required String path
+    }) async => getContents(
+      repository: repository,
+      path: path,
       withProgress: true
     );
 
-    subscribeToRepositoryNotifications(_repository);
-  }
+    void subscribeToRepositoryNotifications({
+      required Repository repository,
+      required String path
+    }) async {
+      _repositorySubscription = repository
+      .subscribe(() { 
+        _syncingCubit?.syncing();
 
-  void shareRepository() async {
-    if (_repository == null) {
-      return;
-    }
-
-    final token = await _repository!.createShareToken(name: _repositoryName);
-    print('Token for sharing repository $_repositoryName: $token');
-    
-    await _showShareRepository(context, _repositoryName, token);
-  }
-
-  _repositoryContentBuilder() => BlocConsumer<DirectoryBloc, DirectoryState>(
-    buildWhen: (context, state) {
-      return !(state is SyncingInProgress);
-    },
-    builder: (context, state) {
-      if (state is DirectoryInitial) {
-        return Center(
-          child: Text(
-            Strings.messageLoadingContents,
-            style: TextStyle(
-              fontSize: 23.0,
-              fontWeight: FontWeight.bold
-            )
-          )
+        getContents(
+          repository: repository,
+          path: path,
+          isSyncing: true
         );
-      }
-
-      if (state is DirectoryLoadInProgress) {
-        return Center(child: CircularProgressIndicator());
-      }
-
-      if (state is DirectoryLoadSuccess) {
-        if (state.path == _currentFolder) {
-          return _selectLayoutWidget(isContentsEmpty: state.contents.isEmpty);  
-        }
-        return _selectLayoutWidget(isContentsEmpty: _folderContents.isEmpty);
-      }
-      
-      if (state is NavigationLoadSuccess) {
-        return _selectLayoutWidget(isContentsEmpty: state.contents.isEmpty);
-      }
-
-      if (state is DirectoryLoadFailure) {
-        return _errorState();
-      }
-
-      if (state is NavigationLoadFailure) {
-        return _errorState();
-      }
-
-      return Center(child: Text('Ooops!'));
-    },
-    listener: (context, state) {
-      if (state is NavigationLoadSuccess) {
-        if (state.type == Navigation.content) {
-          setState(() { 
-            _currentFolder = state.destination;
-            print('Current path updated: $_currentFolder');
-          });
-
-          updateFolderContents(state.contents);
-          updateRoute(state.destination);
-
-          return;
-        }
-      }
-
-      if (state is SyncingInProgress) {
-        _syncingCubit.syncing();
-        return;
-      }
-
-      if (state is DirectoryLoadSuccess) {
-        if (state.isSyncing) {  
-          _syncingCubit.done();
-
-          if (state.path == _currentFolder) {
-            updateFolderContents(state.contents);    
-          }
-
-          return;
-        }
-
-        updateFolderContents(state.contents);
-        return;
-      }
-
-      if (state is DirectoryLoadFailure) {
-        if (state.isSyncing) {
-          _syncingCubit.failed();
-        }
-
-        return;
-      }
-    }
-  );
-
-  _selectLayoutWidget({isContentsEmpty}) {
-    if (isContentsEmpty) {
-      return _noContents();
+      });
     }
 
-    return _contentsList();
-  }
-
-  Future<void> updateFolderContents(newContent) async {
-    if (newContent.isEmpty) {
-      if (_folderContents.isNotEmpty) {
-          setState(() {
-            _folderContents.clear();
-          }); 
-      }
-      return;
-    }
-
-    final orderedContent = newContent as List<BaseItem>;
-    orderedContent.sort((a, b) => a.itemType.index.compareTo(b.itemType.index));
-    
-    if (!DeepCollectionEquality.unordered().equals(orderedContent, _folderContents)) {
-        setState(() {
-          _folderContents = orderedContent;
-        });
-    }
-  }
-
-  _errorState() => Column(
-    mainAxisAlignment: MainAxisAlignment.center,
-    crossAxisAlignment: CrossAxisAlignment.center,
-    children: [
-      Align(
-        alignment: Alignment.center,
-        child: Text(
-          Strings.messageOhOh,
-          textAlign: TextAlign.center,
-          style: TextStyle(
-            fontSize: 24.0,
-            fontWeight: FontWeight.bold,
-            color: Colors.red
-          ),
+    @override
+    Widget build(BuildContext context) {
+      return Scaffold(
+        key: _scaffoldKey,
+        appBar: _buildOuiSyncBar(repository: _repository),
+        body: _mainState,
+        floatingActionButton: _buildFAB(context,
+          repository: _repository,
+          path: _currentFolder
         ),
-      ),
-      SizedBox(height: 20.0),
-      Align(
-        alignment: Alignment.center,
-        child: StyledText(
-          text: Strings.messageErrorState,
-          style: TextStyle(
-            fontSize: 16.0,
-            fontWeight: FontWeight.normal,
-            color: Colors.red
-          ),
-          styles: {
-            'bold': TextStyle(fontWeight: FontWeight.bold),
-            'arrow_down': IconStyle(Icons.south),
-          },
-        ),
-      ),
-      SizedBox(height: 20.0),
-      ElevatedButton(
-        onPressed: refreshCurrent,
-        child: Text('Reload')
-      ),
-    ],
-  );
+      );
+    }
 
-  _noRepositories() => Column(
-    mainAxisAlignment: MainAxisAlignment.center,
-    crossAxisAlignment: CrossAxisAlignment.center,
-    children: [
-      Align(
-        alignment: Alignment.center,
-        child: Text(
-          Strings.messageNoRepos,
-          textAlign: TextAlign.center,
-          style: TextStyle(
-            fontSize: 24.0,
-            fontWeight: FontWeight.bold
+    _buildOuiSyncBar({required Repository? repository}) => OuiSyncBar(
+      appBranding: AppBranding(appName: Strings.titleApp),
+      centralWidget: Container(), //SearchBar(), |removed until implemented
+      actions: [
+        Padding(
+          padding: EdgeInsets.only(right: 10.0),
+          child: Fields.actionIcon(
+            icon: Icons.settings_outlined,
+            onTap: () async {
+              bool dhtStatus = await repository?.isDhtEnabled() ?? false;
+              
+              settingsAction(
+                BlocProvider.of<RepositoriesCubit>(context),
+                BlocProvider.of<SynchronizationCubit>(context),
+                dhtStatus
+              );
+            },
+            size: 35.0,
+            color: Theme.of(context).colorScheme.surface
           ),
-        ),
-      ),
-      SizedBox(height: 20.0),
-      Align(
-        alignment: Alignment.center,
-        child: Fields.inPageSecondaryMessage(
-          Strings.messageCreateNewRepoStyled,
-          tags: {
-            'bold': StyledTextTag(style: TextStyle(fontWeight: FontWeight.bold)),
-            'arrow_down': StyledTextIconTag(Icons.south),
-          }
         )
+      ],
+      bottom: CustomNavigationBar(
+        repositoriesCubit: BlocProvider.of<RepositoriesCubit>(context),
+        synchronizationCubit: BlocProvider.of<SynchronizationCubit>(context),
+        onRepositorySelect: switchRepository,
+        shareRepositoryOnTap: shareRepository,
       ),
-      SizedBox(height: 20.0),
-      ElevatedButton(
-        onPressed: () => createRepoDialog(BlocProvider.of<RepositoriesCubit>(context)),
-        child: Text('Create a Repository')
-      ),
-      ElevatedButton(
-        onPressed: () => addRepoWithTokenDialog(BlocProvider.of<RepositoriesCubit>(context)),
-        child: Text('Add a Shared Repository')
-      ),
-    ],
-  );
+      mode: BarMode.full,
+      toolbarHeight: 200.0,
+      preferredSize: Size.fromHeight(200.0)
+    );
 
-  _noContents() => RefreshIndicator(
-      onRefresh: refreshCurrent,
+    StatelessWidget _buildFAB(BuildContext context,
+    {
+      required Repository? repository,
+      required String path
+    }) {
+      return repository != null
+      ? new FloatingActionButton(
+        heroTag: Constants.heroTagMainPageActions,
+        child: const Icon(Icons.add_rounded),
+        onPressed: () => _showDirectoryActions(
+          context, 
+          BlocProvider.of<DirectoryBloc>(context), 
+          repository, 
+          path
+        ),
+      )
+      : Container();
+    }
+
+    void switchRepository(Repository repository, String name) {
+      assert((_repository?.handle ?? 0) != repository.handle);
+
+      if (_repositorySubscription != null) {
+        _repositorySubscription!.cancel();
+        print('Repository subscription closed');
+      }
+
+      if (_repository != null) {
+        _repository!.close();
+        print('Repository closed'); 
+      }
+
+      NativeChannels.setRepository(repository);
+
+      _repository = repository;
+      _repositoryName = name;
+
+      switchMainState(newState: _repositoryContentBuilder());
+
+      navigateToPath(
+        repository: repository,
+        type: Navigation.content,
+        origin: Strings.rootPath,
+        destination: Strings.rootPath,
+        withProgress: true
+      );
+
+      subscribeToRepositoryNotifications(
+        repository: repository,
+        path: Strings.rootPath
+      );
+    }
+
+    void shareRepository() async {
+      if (_repository == null) {
+        return;
+      }
+
+      final token = await _repository!
+      .createShareToken(name: _repositoryName);
+      
+      print('Token for sharing repository $_repositoryName: $token');
+      
+      await _showShareRepository(context, repositoryName: _repositoryName, token: token);
+    }
+
+    _repositoryContentBuilder() => BlocConsumer<DirectoryBloc, DirectoryState>(
+      buildWhen: (context, state) {
+        return !(state is SyncingInProgress);
+      },
+      builder: (context, state) {
+        if (state is DirectoryInitial) {
+          return Center(
+            child: Fields.inPageSecondaryMessage(Strings.messageLoadingContents)
+          );
+        }
+
+        if (state is DirectoryLoadInProgress) {
+          return Center(child: CircularProgressIndicator());
+        }
+
+        if (state is DirectoryLoadSuccess) {
+          if (state.path == _currentFolder) {
+            return _selectLayoutWidget(
+              repository: _repository!,
+              path: _currentFolder,
+              isContentsEmpty: state.contents.isEmpty
+            );  
+          }
+          return _selectLayoutWidget(
+            repository: _repository!,
+            path: _currentFolder,
+            isContentsEmpty: _folderContents.isEmpty
+          );
+        }
+        
+        if (state is NavigationLoadSuccess) {
+          return _selectLayoutWidget(
+            repository: _repository!,
+            path: _currentFolder,
+            isContentsEmpty: state.contents.isEmpty
+          );
+        }
+
+        if (state is DirectoryLoadFailure) {
+          return _errorState(
+            message: Strings.messageErrorState,
+            actionReload: () => refreshCurrent(repository: _repository!, path: _currentFolder)
+          );
+        }
+
+        if (state is NavigationLoadFailure) {
+          return _errorState(
+            message: Strings.messageErrorState,
+            actionReload: () => refreshCurrent(repository: _repository!, path: _currentFolder)
+          );
+        }
+
+        return _errorState(
+          message: Strings.messageErrorLoadingContents,
+          actionReload: () => refreshCurrent(repository: _repository!, path: _currentFolder)
+        );
+      },
+      listener: (context, state) {
+        if (state is NavigationLoadSuccess) {
+          if (state.type == Navigation.content) {
+            
+            print('Current path updated: $_currentFolder, ${state.contents.length} entries');
+
+            updateCurrentFolder(path: state.destination);
+            updateFolderContents(newContent: state.contents);
+            updateRoute(
+              repository: _repository!,
+              destination: state.destination
+            );
+
+            return;
+          }
+        }
+
+        if (state is SyncingInProgress) {
+          _syncingCubit?.syncing();
+          return;
+        }
+
+        if (state is DirectoryLoadSuccess) {
+          if (state.isSyncing) {  
+            _syncingCubit?.done();
+
+            if (state.path == _currentFolder) {
+              updateFolderContents(newContent: state.contents as List<BaseItem>);    
+            }
+
+            return;
+          }
+
+          updateFolderContents(newContent: state.contents as List<BaseItem>);
+          return;
+        }
+
+        if (state is DirectoryLoadFailure) {
+          if (state.isSyncing) {
+            _syncingCubit?.failed();
+          }
+
+          return;
+        }
+      }
+    );
+
+    _selectLayoutWidget({
+      required Repository repository,
+      required String path,
+      required bool isContentsEmpty
+    }) {
+      if (isContentsEmpty) {
+        return _noContents(repository: repository, path: path);
+      }
+
+      return _contentsList(repository: repository, path: path);
+    }
+
+    Future<void> updateFolderContents({required List<BaseItem> newContent}) async {
+      if (newContent.isEmpty) {
+        if (_folderContents.isNotEmpty) {
+          setState(() { _folderContents.clear(); }); 
+        }
+        return;
+      }
+
+      final orderedContent = newContent;
+      orderedContent.sort((a, b) => a.itemType.index.compareTo(b.itemType.index));
+      
+      if (!DeepCollectionEquality.unordered().equals(orderedContent, _folderContents)) {
+        setState(() {_folderContents  = orderedContent; });
+      }
+    }
+
+    _errorState({
+      required String message,
+      required Function actionReload
+    }) => Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        Align(
+          alignment: Alignment.center,
+          child: Fields.inPageMainMessage(
+            Strings.messageOhOh,
+            color: Colors.red,
+            tags: {
+              Constants.inlineTextColor: InlineTextStyles.color(Colors.black),
+              Constants.inlineTextSize: InlineTextStyles.size(),
+              Constants.inlineTextBold: InlineTextStyles.bold
+            }
+          )
+        ),
+        SizedBox(height: 10.0),
+        Align(
+          alignment: Alignment.center,
+          child: Fields.inPageSecondaryMessage(
+            message,
+            tags: {
+              Constants.inlineTextSize: InlineTextStyles.size(),
+              Constants.inlineTextBold: InlineTextStyles.bold,
+              Constants.inlineTextIcon: InlineTextStyles.icon(Icons.south)
+            }
+          )
+        ),
+        SizedBox(height: 20.0),
+        Fields.inPageButton(
+          onPressed: () => actionReload,
+          text: Strings.actionReloadContents,
+          size: Size(100.0, 40.0),
+          fontSize: 16.0,
+          autofocus: true
+        )
+      ],
+    );
+
+    _noRepositoriesState() => Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        Align(
+          alignment: Alignment.center,
+          child: Fields.inPageMainMessage(Strings.messageNoRepos),
+        ),
+        SizedBox(height: 10.0),
+        Align(
+          alignment: Alignment.center,
+          child: Fields.inPageSecondaryMessage(
+            Strings.messageCreateNewRepo,
+            tags: { Constants.inlineTextBold: InlineTextStyles.bold }
+          )
+        ),
+        SizedBox(height: 30.0),
+        Fields.inPageButton(
+          onPressed: () => createRepoDialog(BlocProvider.of<RepositoriesCubit>(context)),
+          text: Strings.actionCreateRepository,
+          size: Size(250.0, 40.0),
+          fontSize: 16.0,
+          autofocus: true
+        ),
+        SizedBox(height: 20.0),
+        Fields.inPageButton(
+          onPressed: () => addRepoWithTokenDialog(BlocProvider.of<RepositoriesCubit>(context)),
+          text: Strings.actionAddRepositoryWithToken,
+          size: Size(250.0, 40.0),
+          fontSize: 16.0
+        ),
+      ],
+    );
+
+    _noContents({
+      required Repository repository,
+      required String path
+    }) => RefreshIndicator(
+      onRefresh: () => refreshCurrent(repository: repository, path: path),
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
         crossAxisAlignment: CrossAxisAlignment.center,
         children: [
           Align(
             alignment: Alignment.center,
-            child: Text(
-              _currentFolder.isEmpty
+            child: Fields.inPageMainMessage(
+              path.isEmpty
               ? Strings.messageEmptyRepo
               : Strings.messageEmptyFolder,
-              textAlign: TextAlign.center,
-              style: TextStyle(
-                fontSize: 24.0,
-                fontWeight: FontWeight.bold
-              ),
             ),
           ),
-          SizedBox(height: 20.0),
+          SizedBox(height: 10.0),
           Align(
             alignment: Alignment.center,
             child: Fields.inPageSecondaryMessage(
-              Strings.messageCreateAddNewItemStyled,
+              Strings.messageCreateAddNewItem,
               tags: {
-                'bold': StyledTextTag(style: TextStyle(fontWeight: FontWeight.bold)),
-                'add_circle': StyledTextIconTag(
+                Constants.inlineTextBold: InlineTextStyles.bold,
+                Constants.inlineTextIcon: InlineTextStyles.icon(
                   Icons.add_circle,
                   size: 34.0,
                   color: Theme.of(context).primaryColor
-                ),
+                )
               }
             ),
           ),
@@ -512,157 +621,192 @@ class _MainPageState extends State<MainPage>
       )
     );
 
-  _contentsList() => RefreshIndicator(
-    onRefresh: refreshCurrent,
-    child: ListView.separated(
-      padding: const EdgeInsets.only(bottom: kFloatingActionButtonMargin + 48),
-      separatorBuilder: (context, index) => Divider(
-          height: 1,
-          color: Colors.transparent
-      ),
-      itemCount: _folderContents.length,
-      itemBuilder: (context, index) {
-        final item = _folderContents[index];
-        final actionByType = item.itemType == ItemType.file
-        ? () async {
-          if (_persistentBottomSheetController != null) {
-            await Dialogs.simpleAlertDialog(
-              context: context,
-              title: 'Moving entry',
-              message: 'This function is not availabe when moving an entry'
-            );
-            return;
-          }
-
-          final fileSize = await EntryInfo(_repository!).fileLength(item.path);
-          _showFileDetails(BlocProvider.of<DirectoryBloc>(context), item.name, item.path, fileSize);
-        }
-        : () {
-          if (_persistentBottomSheetController != null &&
-          _pathEntryToMove == item.path) {
-            return;
-          }
-
-          navigateToPath(
-            type: Navigation.content,
-            origin: _currentFolder,
-            destination: item.path,
-            withProgress: true
-          );
-        };
-
-        final listItem = ListItem (
-          repository: _repository!,
-          itemData: item,
-          mainAction: actionByType,
-          secondaryAction: () => {},
-          filePopupMenu: _popupMenu(item),
-          folderDotsAction: () async {
+    _contentsList({
+      required Repository repository,
+      required String path
+    }) => RefreshIndicator(
+      onRefresh: () => refreshCurrent(repository: repository, path: path),
+      child: ListView.separated(
+        padding: const EdgeInsets.only(bottom: kFloatingActionButtonMargin + 48),
+        separatorBuilder: (context, index) => Divider(
+            height: 1,
+            color: Colors.transparent
+        ),
+        itemCount: _folderContents.length,
+        itemBuilder: (context, index) {
+          final item = _folderContents[index];
+          final actionByType = item.itemType == ItemType.file
+          ? () async {
             if (_persistentBottomSheetController != null) {
               await Dialogs.simpleAlertDialog(
                 context: context,
-                title: 'Moving entry',
-                message: 'This function is not availabe when moving an entry'
+                title: Strings.titleMovingEntry,
+                message: Strings.messageMovingEntry
               );
               return;
             }
-            
-            await _showFolderDetails(
-              BlocProvider.of<DirectoryBloc>(context),
-              removeParentFromPath(item.path),
-              item.path
+
+            final fileSize = await EntryInfo(repository).fileLength(item.path);
+            _showFileDetails(
+              repository: repository,
+              directoryBloc: BlocProvider.of<DirectoryBloc>(context),
+              scaffoldKey: _scaffoldKey,
+              name: item.name,
+              path: item.path,
+              size: fileSize
             );
           }
-        );
+          : () {
+            if (_persistentBottomSheetController != null &&
+            _pathEntryToMove == item.path) {
+              return;
+            }
 
-        return listItem;
+            navigateToPath(
+              repository: repository,
+              type: Navigation.content,
+              origin: path,
+              destination: item.path,
+              withProgress: true
+            );
+          };
+
+          final listItem = ListItem (
+            repository: repository,
+            itemData: item,
+            mainAction: actionByType,
+            secondaryAction: () => {},
+            filePopupMenu: _popupMenu(repository: repository, data: item),
+            folderDotsAction: () async {
+              if (_persistentBottomSheetController != null) {
+                await Dialogs
+                .simpleAlertDialog(
+                  context: context,
+                  title: Strings.titleMovingEntry,
+                  message: Strings.messageMovingEntry
+                );
+
+                return;
+              }
+              
+              await _showFolderDetails(
+                repository: repository,
+                directoryBloc: BlocProvider.of<DirectoryBloc>(context),
+                scaffoldKey: _scaffoldKey,
+                name: removeParentFromPath(item.path),
+                path: item.path
+              );
+            }
+          );
+
+          return listItem;
+        }
+      )
+    );
+
+    _popupMenu({
+      required Repository repository,
+      required BaseItem data
+    }) => Dialogs
+    .filePopupMenu(
+      context,
+      repository,
+      BlocProvider. of<DirectoryBloc>(context),
+      { 
+        Strings.actionPreviewFile: data,
+        Strings.actionShareFile: data,
+        Strings.actionDeleteFile: data 
       }
-    )
-  );
+    );
 
-  _popupMenu(item) => Dialogs
-  .filePopupMenu(
-    context,
-    _repository!,
-    BlocProvider. of<DirectoryBloc>(context),
-    { 
-      Strings.actionPreviewFile: item,
-      Strings.actionShareFile: item,
-      Strings.actionDeleteFile: item 
-    }
-  );
-
-  Future<dynamic> _showShareRepository(context, repositoryName, token) => showModalBottomSheet(
-    isScrollControlled: true,
-    context: context, 
-    shape: RoundedRectangleBorder(
-      borderRadius: BorderRadius.only(
-        topLeft: Radius.circular(20.0),
-        topRight: Radius.circular(20.0),
-        bottomLeft: Radius.zero,
-        bottomRight: Radius.zero
+    Future<dynamic> _showShareRepository(context,
+    {
+      required String repositoryName,
+      required String token
+    }) => showModalBottomSheet(
+      isScrollControlled: true,
+      context: context, 
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.only(
+          topLeft: Radius.circular(20.0),
+          topRight: Radius.circular(20.0),
+          bottomLeft: Radius.zero,
+          bottomRight: Radius.zero
+        ),
       ),
-    ),
-    builder: (context) {
-      return ShareRepository(
-        repositoryName: repositoryName,
-        token: token,
-      );
-    }
-  );
+      builder: (context) {
+        return ShareRepository(
+          repositoryName: repositoryName,
+          token: token,
+        );
+      }
+    );
 
-  Future<dynamic> _showFileDetails(bloc, name, path, size) => showModalBottomSheet(
-    isScrollControlled: true,
-    context: context, 
-    shape: RoundedRectangleBorder(
-      borderRadius: BorderRadius.only(
-        topLeft: Radius.circular(20.0),
-        topRight: Radius.circular(20.0),
-        bottomLeft: Radius.zero,
-        bottomRight: Radius.zero
+    Future<dynamic> _showFileDetails({
+      required Repository repository,
+      required DirectoryBloc directoryBloc,
+      required GlobalKey<ScaffoldState> scaffoldKey,
+      required String name,
+      required String path,
+      required int size
+    }) => showModalBottomSheet(
+      isScrollControlled: true,
+      context: context, 
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.only(
+          topLeft: Radius.circular(20.0),
+          topRight: Radius.circular(20.0),
+          bottomLeft: Radius.zero,
+          bottomRight: Radius.zero
+        ),
       ),
-    ),
-    builder: (context) {
-      return FileDetail(
-        context: context,
-        bloc: bloc,
-        repository: _repository!,
-        name: name,
-        path: path,
-        parent: extractParentFromPath(path),
-        size: size,
-        scaffoldKey: _scaffoldKey,
-        onBottomSheetOpen: retrieveBottomSheetController,
-        onMoveEntry: moveEntry
-      );
-    }
-  );
+      builder: (context) {
+        return FileDetail(
+          context: context,
+          bloc: directoryBloc,
+          repository: repository,
+          name: name,
+          path: path,
+          parent: extractParentFromPath(path),
+          size: size,
+          scaffoldKey: scaffoldKey,
+          onBottomSheetOpen: retrieveBottomSheetController,
+          onMoveEntry: moveEntry
+        );
+      }
+    );
 
-  Future<dynamic> _showFolderDetails(bloc, name, path) => showModalBottomSheet(
-    isScrollControlled: true,
-    context: context, 
-    shape: RoundedRectangleBorder(
-      borderRadius: BorderRadius.only(
-        topLeft: Radius.circular(20.0),
-        topRight: Radius.circular(20.0),
-        bottomLeft: Radius.zero,
-        bottomRight: Radius.zero
+    Future<dynamic> _showFolderDetails({
+      required Repository repository,
+      required DirectoryBloc directoryBloc,
+      required GlobalKey<ScaffoldState> scaffoldKey,
+      required String name,
+      required String path
+    }) => showModalBottomSheet(
+      isScrollControlled: true,
+      context: context, 
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.only(
+          topLeft: Radius.circular(20.0),
+          topRight: Radius.circular(20.0),
+          bottomLeft: Radius.zero,
+          bottomRight: Radius.zero
+        ),
       ),
-    ),
-    builder: (context) {
-      return FolderDetail(
-        context: context,
-        bloc: bloc,
-        repository: _repository!,
-        name: name,
-        path: path,
-        parent: extractParentFromPath(path),
-        scaffoldKey: _scaffoldKey,
-        onBottomSheetOpen: retrieveBottomSheetController,
-        onMoveEntry: moveEntry
-      );
-    }
-  );
+      builder: (context) {
+        return FolderDetail(
+          context: context,
+          bloc: directoryBloc,
+          repository: repository,
+          name: name,
+          path: path,
+          parent: extractParentFromPath(path),
+          scaffoldKey: scaffoldKey,
+          onBottomSheetOpen: retrieveBottomSheetController,
+          onMoveEntry: moveEntry
+        );
+      }
+    );
 
   void retrieveBottomSheetController(PersistentBottomSheetController? controller, String entryPath) {
     _persistentBottomSheetController = controller;
@@ -685,8 +829,7 @@ class _MainPageState extends State<MainPage>
         origin: origin,
         destination: _currentFolder,
         entryPath: path,
-        newDestinationPath: newDestinationPath,
-        navigate: false
+        newDestinationPath: newDestinationPath
       )
     );
   }
@@ -720,7 +863,7 @@ class _MainPageState extends State<MainPage>
         final formKey = GlobalKey<FormState>();
 
         return ActionsDialog(
-          title: 'Create Repository',
+          title: Strings.titleCreateRepository,
           body: RepositoryCreation(
             context: context,
             cubit: cubit,
@@ -729,8 +872,8 @@ class _MainPageState extends State<MainPage>
         );
       }
     ).then((newRepository) {
-      if (newRepository.isNotEmpty) { // If a folder is created, the new folder is returned path; otherwise, empty string.
-        switchMainState(_repositoryContentBuilder());
+      if (newRepository.isNotEmpty) { // If a repository is created, the new repository name is returned; otherwise, empty string.
+        switchMainState(newState: _repositoryContentBuilder());
       }
     });
   }
@@ -743,7 +886,7 @@ class _MainPageState extends State<MainPage>
         final formKey = GlobalKey<FormState>();
 
         return ActionsDialog(
-          title: 'Add Repository',
+          title: Strings.titleAddRepository,
           body: AddRepositoryWithToken(
             context: context,
             cubit: cubit,
@@ -752,8 +895,8 @@ class _MainPageState extends State<MainPage>
         );
       }
     ).then((addedRepository) {
-      if (addedRepository.isNotEmpty) { // If a repository is successfuly created, the new repository name is returned; otherwise, empty string.
-        switchMainState(_repositoryContentBuilder());
+      if (addedRepository.isNotEmpty) { // If a repository is created, the new repository name is returned; otherwise, empty string.
+        switchMainState(newState: _repositoryContentBuilder());
       }
     });
   }
@@ -766,7 +909,7 @@ class _MainPageState extends State<MainPage>
           repositoriesCubit: reposCubit,
           synchronizationCubit: syncCubit,
           onRepositorySelect: switchRepository,
-          title: 'Settings',
+          title: Strings.titleSettings,
           currentRepository: _repository,
           currentRepositoryName: _repositoryName,
           dhtStatus: dhtStatus,

--- a/lib/app/pages/settings_page.dart
+++ b/lib/app/pages/settings_page.dart
@@ -123,6 +123,10 @@ class _SettingsPageState extends State<SettingsPage> {
   }
 
   Future<void> updateDhtSetting(bool enable) async {
+    if (widget.currentRepository == null) {
+      return;
+    }
+
     print('${enable ? 'Enabling': 'Disabling'} BitTorrent DHT...');
 
     enable ? await widget.currentRepository!.enableDht()

--- a/lib/app/pages/settings_page.dart
+++ b/lib/app/pages/settings_page.dart
@@ -74,11 +74,11 @@ class _SettingsPageState extends State<SettingsPage> {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          buildIconLabel(
-            Icons.lock_rounded,
-            'Repository',
-            infoSize: 25.0,
-            labelPadding: EdgeInsets.fromLTRB(20.0, 0.0, 10.0, 20.0)
+          Fields.iconText(
+            icon: Icons.lock_rounded,
+            text: 'Repository',
+            textSize: 25.0,
+            padding: EdgeInsets.fromLTRB(20.0, 0.0, 10.0, 20.0)
             ),
           RepositoryPicker(
             repositoriesCubit: widget.repositoriesCubit,
@@ -114,7 +114,7 @@ class _SettingsPageState extends State<SettingsPage> {
 
   Widget _buildDhtSection() {
     return SwitchListTile(
-      title: buildConstrainedText('BitTorrent DHT'),
+      title: Fields.constrainedText('BitTorrent DHT'),
       value: _bittorrentDhtStatus,
       onChanged: (bool value) {
         updateDhtSetting(value);

--- a/lib/app/pages/settings_page.dart
+++ b/lib/app/pages/settings_page.dart
@@ -37,7 +37,8 @@ class _SettingsPageState extends State<SettingsPage> {
   void initState() {
     super.initState();
 
-    _bittorrentDhtStatus = widget.dhtStatus;  
+    _bittorrentDhtStatus = widget.dhtStatus;
+    print('BitTorrent DHT status: ${widget.dhtStatus}');
   }
 
   @override
@@ -122,6 +123,8 @@ class _SettingsPageState extends State<SettingsPage> {
   }
 
   Future<void> updateDhtSetting(bool enable) async {
+    print('${enable ? 'Enabling': 'Disabling'} BitTorrent DHT...');
+
     enable ? await widget.currentRepository!.enableDht()
     : await widget.currentRepository!.disableDht();
     
@@ -130,12 +133,13 @@ class _SettingsPageState extends State<SettingsPage> {
       _bittorrentDhtStatus = isEnabled;
     });
 
-    String toastMessage = 'BitTorrent DHT is ${isEnabled ? 'enabled' : 'disabled'}';
+    String dhtStatusMessage = 'BitTorrent DHT is ${isEnabled ? 'enabled' : 'disabled'}';
     if (enable != isEnabled) {
-      toastMessage = enable ? 'BitTorrent DHT could not be enabled'
+      dhtStatusMessage = enable ? 'BitTorrent DHT could not be enabled'
       : 'Disable BitTorrent DHT failed.';
     }
 
-    showToast(toastMessage);
+    print(dhtStatusMessage);
+    showToast(dhtStatusMessage);
   }
 }

--- a/lib/app/utils/constants.dart
+++ b/lib/app/utils/constants.dart
@@ -36,4 +36,18 @@ class Constants{
   static const String localRepositoriesKey = 'LOCAL_REPOS';
   static const String currentRepositoryKey = 'CURRENT_REPO';
   static const String sessionStoreKey = 'SESSION_STORE';
+
+  /// In-line text style names
+  
+  static const String inlineTextBold = 'bold';
+  static const String inlineTextSize = 'size';
+  static const String inlineTextColor = 'color';
+  static const String inlineTextIcon = 'icon';
+
+  // Hero tags
+
+  static const String heroTagMainPageActions = 'MAIN_PAGE_ACTIONS';
+
+  static const String heroTagCreateFolderSharedFile = 'CREATE_FOLDER_SHARED_FILE';
+  static const String heroTagSaveToFolderSharedFile = 'SAVE_TO_FOLDER_SHARED_FILE';
 }

--- a/lib/app/utils/entry_info.dart
+++ b/lib/app/utils/entry_info.dart
@@ -53,10 +53,10 @@ class EntryInfo {
       length = await file.length;
     } catch (e) {
       print('Error getting the length for file $path:\n${e.toString()}');
-    } finally {
-      if (file != null) {
-        file.close(); 
-      }      
+    }
+
+    if (file != null) {
+      file.close(); 
     }
     
     return length;

--- a/lib/app/utils/fields.dart
+++ b/lib/app/utils/fields.dart
@@ -80,18 +80,29 @@ class Fields {
     padding
   );
 
-  static ElevatedButton _elevatedButtonBase ({
+  static ElevatedButton inPageButton ({
     required Function()? onPressed,
     required String text,
-    ButtonStyle? style,
+    Alignment alignment = Alignment.center,
+    Size? size,
+    double? fontSize,
+    FontWeight fontWeight = FontWeight.normal,
+    FontStyle fontStyle = FontStyle.normal,
+    Color color = Colors.white,
     bool autofocus = false,
   }) => ElevatedButton(
     onPressed: onPressed,
-    child: Container(
-
-      child: Text(text)
+    child: Text(text),
+    style: ButtonStyle(
+      alignment: alignment,
+      minimumSize: MaterialStateProperty.all<Size?>(size),
+      textStyle: MaterialStateProperty.all<TextStyle>(TextStyle(
+        fontSize: fontSize,
+        fontWeight: fontWeight,
+        fontStyle: fontStyle,
+        color: color
+      )),
     ),
-    style: style,
     autofocus: autofocus,
   );
 

--- a/lib/app/utils/fields.dart
+++ b/lib/app/utils/fields.dart
@@ -5,48 +5,94 @@ import 'package:styled_text/styled_text.dart';
 class Fields {
   Fields._();
 
-  static StyledText _styledTextBase(
+  static Widget _styledTextBase(
     String message,
     TextAlign textAlign,
     double fontSize,
     FontWeight fontWeight,
-    Map<String, StyledTextTagBase>? tags
-  ) => StyledText(
-    text: message,
-    textAlign: textAlign,
-    style: TextStyle(
-      fontSize: fontSize,
-      fontWeight: fontWeight
-    ),
-    tags: tags
-  );
+    FontStyle fontStyle,
+    Color color,
+    Map<String, StyledTextTagBase>? tags,
+    EdgeInsets padding
+  ) {
+    if (tags == null) {
+      tags = Map<String, StyledTextTagBase>();
+    }
+    
+    tags.addAll({
+      'font': StyledTextTag(
+        style: TextStyle(
+          fontSize: fontSize,
+          fontWeight: fontWeight,
+          fontStyle: fontStyle,
+          color: color
+        )
+      )
+    });
 
-  static StyledText inPageMainMessage(String message,
+    return Container(
+      padding: padding,
+      child: StyledText(
+        text: '<font>$message</font>',
+        textAlign: textAlign,
+        tags: tags
+      )
+    );
+  }
+
+  static Widget inPageMainMessage(String message,
   {
     TextAlign textAlign = TextAlign.center,
     double fontSize = 24.0,
     FontWeight fontWeight = FontWeight.bold,
-    Map<String, StyledTextTagBase>? tags
+    FontStyle fontStyle = FontStyle.normal,
+    Color color = Colors.black,
+    Map<String, StyledTextTagBase>? tags,
+    EdgeInsets padding = const EdgeInsets.symmetric(horizontal: 5.0, vertical: 0.0)
   }) => _styledTextBase(
     message,
     textAlign,
     fontSize,
     fontWeight,
-    tags
+    fontStyle,
+    color,
+    tags,
+    padding
   );
 
-  static StyledText inPageSecondaryMessage(String message,
+  static Widget inPageSecondaryMessage(String message,
   {
     TextAlign textAlign = TextAlign.center,
     double fontSize = 18.0,
     FontWeight fontWeight = FontWeight.normal,
-    Map<String, StyledTextTagBase>? tags
+    FontStyle fontStyle = FontStyle.normal,
+    Color color = Colors.black,
+    Map<String, StyledTextTagBase>? tags,
+    EdgeInsets padding = const EdgeInsets.symmetric(horizontal: 10.0, vertical: 0.0)
   }) => _styledTextBase(
     message,
     textAlign,
     fontSize,
     fontWeight,
-    tags
+    fontStyle,
+    color,
+    tags,
+    padding
+  );
+
+  static ElevatedButton _elevatedButtonBase ({
+    required Function()? onPressed,
+    required String text,
+    ButtonStyle? style,
+    bool autofocus = false,
+  }) => ElevatedButton(
+    onPressed: onPressed,
+    child: Container(
+
+      child: Text(text)
+    ),
+    style: style,
+    autofocus: autofocus,
   );
 
   static Widget bottomSheetHandle(BuildContext context,

--- a/lib/app/utils/fields.dart
+++ b/lib/app/utils/fields.dart
@@ -1,235 +1,361 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
+import 'package:styled_text/styled_text.dart';
 
-Widget buildHandle(BuildContext context) {
-  final theme = Theme.of(context);
+class Fields {
+  Fields._();
 
-  return FractionallySizedBox(
-    widthFactor: 0.25,
+  static StyledText _styledTextBase(
+    String message,
+    TextAlign textAlign,
+    double fontSize,
+    FontWeight fontWeight,
+    Map<String, StyledTextTagBase>? tags
+  ) => StyledText(
+    text: message,
+    textAlign: textAlign,
+    style: TextStyle(
+      fontSize: fontSize,
+      fontWeight: fontWeight
+    ),
+    tags: tags
+  );
+
+  static StyledText inPageMainMessage(String message,
+  {
+    TextAlign textAlign = TextAlign.center,
+    double fontSize = 24.0,
+    FontWeight fontWeight = FontWeight.bold,
+    Map<String, StyledTextTagBase>? tags
+  }) => _styledTextBase(
+    message,
+    textAlign,
+    fontSize,
+    fontWeight,
+    tags
+  );
+
+  static StyledText inPageSecondaryMessage(String message,
+  {
+    TextAlign textAlign = TextAlign.center,
+    double fontSize = 18.0,
+    FontWeight fontWeight = FontWeight.normal,
+    Map<String, StyledTextTagBase>? tags
+  }) => _styledTextBase(
+    message,
+    textAlign,
+    fontSize,
+    fontWeight,
+    tags
+  );
+
+  static Widget bottomSheetHandle(BuildContext context,
+  {
+    double widthFactor = 0.25,
+    double verticalMargin = 12.0,
+    double height = 5.0,
+    double borderRadius = 2.5
+  }) => FractionallySizedBox(
+    widthFactor: widthFactor,
     child: Container(
-      margin: const EdgeInsets.symmetric(
-        vertical: 12.0,
+      margin: EdgeInsets.symmetric(
+        vertical: verticalMargin,
       ),
       child: Container(
-        height: 5.0,
+        height: height,
         decoration: BoxDecoration(
-          color: theme.dividerColor,
-          borderRadius: const BorderRadius.all(Radius.circular(2.5)),
+          color: Theme.of(context).dividerColor,
+          borderRadius: BorderRadius.all(Radius.circular(borderRadius)),
         ),
       ),
     ),
   );
-}
 
-Widget buildTitle(title, {
-  size = 24.0,
-  padding = const EdgeInsets.only(bottom: 30.0)
-}) => 
-Padding(
-  padding: padding,
-  child: Column(
-    children: [
-      Text(
-        title,
-        textAlign: TextAlign.center,
-        softWrap: true,
-        overflow: TextOverflow.ellipsis,
-        style: TextStyle(
-          fontSize: size,
-          fontWeight: FontWeight.bold
+  static Widget bottomSheetTitle(String title,
+  {
+    EdgeInsets padding = const EdgeInsets.only(bottom: 30.0),
+    double size = 24.0,
+    TextAlign textAlign = TextAlign.center,
+    bool softWrap = true,
+    TextOverflow textOverflow = TextOverflow.ellipsis,
+    FontWeight fontWeight = FontWeight.bold
+  }) => Padding(
+    padding: padding,
+    child: Column(
+      children: [
+        Text(
+          title,
+          textAlign: textAlign,
+          softWrap: softWrap,
+          overflow: textOverflow,
+          style: TextStyle(
+            fontSize: size,
+            fontWeight: fontWeight
+          ),
         ),
-      ),
-    ]
-  )
-);
-
-Widget buildInfoLabel(label, info, {
-  labelSize = 14.0,
-  infoSize = 18.0,
-  padding: const EdgeInsets.only(top: 20.0)
-}) => 
-Padding(
-  padding: padding,
-  child: Row(
-    mainAxisAlignment: MainAxisAlignment.start,
-    crossAxisAlignment: CrossAxisAlignment.baseline,
-    textBaseline: TextBaseline.alphabetic,
-    children: [
-      buildIdLabel(label, size: labelSize),
-      SizedBox(width: 10.0,),
-      buildConstrainedText(info, size: infoSize)
-    ],
-  )
-);
-
-Widget buildActionIcon({icon, onTap, size = 40.0}) {
-  return GestureDetector(
-    child: Icon(
-      icon,
-      size: size,
-    ),
-    onTap: onTap
+      ]
+    )
   );
-}
 
-Widget buildIconLabel(iconInfo, info, { 
-  iconSize = 30.0,
-  iconColor = Colors.black,
-  infoSize = 18.0,
-  labelPadding = const EdgeInsets.only(bottom: 10.0)
-}) => Padding(
-  padding: labelPadding,
-  child: Row(
-    mainAxisAlignment: MainAxisAlignment.start,
-    crossAxisAlignment: CrossAxisAlignment.center,
-    children: [
-      _buildIcon(iconInfo, size: iconSize),
-      SizedBox(width: 10.0,),
-      buildConstrainedText(info, size: infoSize)
-    ],
-  )
-);
-
-Icon _buildIcon(icon, {
-  size = 30.0,
-  color = Colors.black,
-}) => Icon(
-  icon,
-  size: size,
-  color: color
-);
-
-Widget buildIdLabel(text, {
-  size = 14.0 
-}) => Text(
-  text,
-  textAlign: TextAlign.center,
-  softWrap: true,
-  overflow: TextOverflow.ellipsis,
-  style: TextStyle(
-    fontSize: size,
-    fontWeight: FontWeight.bold
-  ),
-); 
-
-Widget buildConstrainedText(text, {
-  size = 18.0,
-  textAlign = TextAlign.start,
-  softWrap = true,
-  overflow = TextOverflow.clip,
-  fontWeight = FontWeight.w600,
-  color = Colors.black
-})  => Expanded(
-  flex: 1,
-  child: Text(
+  static Widget idLabel(String text,
+  {
+    double size = 14.0,
+    TextAlign textAlign = TextAlign.center,
+    bool softWrap = true,
+    TextOverflow textOverflow = TextOverflow.ellipsis,
+    FontWeight fontWeight = FontWeight.bold,
+    Color color = Colors.black
+  }) => Text(
     text,
     textAlign: textAlign,
     softWrap: softWrap,
-    overflow: overflow,
+    overflow: textOverflow,
     style: TextStyle(
       fontSize: size,
       fontWeight: fontWeight,
       color: color
     ),
-  ),
-);
+  );
 
-Widget buildEntry({
-  required BuildContext context,
-  TextEditingController? textEditingController,
-  required String label,
-  required String hint,
-  required Function(String?) onSaved,
-  required String? Function(String?) validator,
-  AutovalidateMode? autovalidateMode,
-  bool autofocus = false,
-  String? initialValue,
-  Function()? onTap,
-  Function(String)? onChanged,
-  padding = const EdgeInsets.only(bottom: 10.0),
-}) => Padding(
-  padding: padding,
-  child: Column(
-    mainAxisAlignment: MainAxisAlignment.start,
-    crossAxisAlignment: CrossAxisAlignment.baseline,
-    textBaseline: TextBaseline.alphabetic,
-    children: [
-      buildTextFormField(
-        context: context,
-        textEditingController: textEditingController,
-        label: label,
-        hint: hint,
-        onSaved: onSaved,
-        validator: validator,
-        autovalidateMode: autovalidateMode,
-        autofocus: autofocus,
-        initialValue: initialValue,
-        onTap: onTap,
-        onChanged: onChanged
-      )
-    ],
-  )
-);
+  static Widget labeledText({
+    required String label,
+    required String text,
+    double labelSize = 14.0,
+    TextAlign labelTextAlign = TextAlign.center,
+    bool labelSoftWrap = false,
+    TextOverflow labelTextOverflow = TextOverflow.ellipsis,
+    FontWeight labelFontWeight = FontWeight.bold,
+    Color labelColor = Colors.black,
+    double textSize = 18.0,
+    TextAlign textAlign = TextAlign.center,
+    bool textSoftWrap = true,
+    TextOverflow textOverflow = TextOverflow.clip,
+    FontWeight textFontWeight = FontWeight.w600,
+    Color textColor = Colors.black,
+    EdgeInsets padding: const EdgeInsets.only(top: 20.0),
+    double space = 10.0
+  }) => Padding(
+    padding: padding,
+    child: Row(
+      mainAxisAlignment: MainAxisAlignment.start,
+      crossAxisAlignment: CrossAxisAlignment.baseline,
+      textBaseline: TextBaseline.alphabetic,
+      children: [
+        idLabel(
+          label,
+          size: labelSize,
+          textAlign: labelTextAlign,
+          softWrap: labelSoftWrap,
+          textOverflow: labelTextOverflow,
+          fontWeight: labelFontWeight,
+          color: labelColor
+        ),
+        SizedBox(width: space,),
+        constrainedText(text,
+          size: textSize,
+          textAlign: textAlign,
+          softWrap: textSoftWrap,
+          textOverflow: textOverflow,
+          fontWeight: textFontWeight,
+          color: textColor
+        )
+      ],
+    )
+  );
 
-Widget buildTextFormField({
-  required BuildContext context,
-  TextEditingController? textEditingController,
-  required String label,
-  required String hint,
-  required Function(String?) onSaved,
-  required String? Function(String?) validator,
-  AutovalidateMode? autovalidateMode,
-  bool autofocus = false,
-  String? initialValue,
-  Function()? onTap,
-  Function(String)? onChanged
-}) => TextFormField(
-  controller: textEditingController,
-  autovalidateMode: autovalidateMode,
-  autofocus: autofocus,
-  initialValue: initialValue,  
-  keyboardType: TextInputType.text,
-  decoration: InputDecoration (
-    icon: const Icon(Icons.folder),
-    hintText: hint,
-    labelText: label,
-  ),
-  validator: validator,
-  onSaved: onSaved,
-  onTap: onTap,
-  onChanged: onChanged,
-);
+  static Widget constrainedText(String text,
+  {
+    double size = 18.0,
+    TextAlign textAlign = TextAlign.start,
+    bool softWrap = true,
+    TextOverflow textOverflow = TextOverflow.clip,
+    FontWeight fontWeight = FontWeight.w600,
+    Color color = Colors.black
+  })  => Expanded(
+    flex: 1,
+    child: Text(
+      text,
+      textAlign: textAlign,
+      softWrap: softWrap,
+      overflow: textOverflow,
+      style: TextStyle(
+        fontSize: size,
+        fontWeight: fontWeight,
+        color: color
+      ),
+    ),
+  );
 
-Widget buildActionsSection(context, List<Widget> buttons, {
-  padding = const EdgeInsets.only(top: 20.0)
-}) => 
-Padding(
-  padding: padding,
-  child: Row(
-    mainAxisAlignment: MainAxisAlignment.end,
-    mainAxisSize: MainAxisSize.max,
-    children: buttons
-  )
-);
+  static Icon _iconBase(IconData icon,
+  {
+    double size = 30.0,
+    Color color = Colors.black,
+  }) => Icon(
+    icon,
+    size: size,
+    color: color
+  );
 
-Widget buildRoundedButton(BuildContext context, Icon icon, String text, Function action, {
-  double buttonSize = 60.0,
-  double textSize = 13.0
-}) {
-  return  Column(
+  static Widget actionIcon({
+    required IconData icon,
+    required Function()? onTap,
+    double size = 40.0,
+    Color color = Colors.black
+  }) => GestureDetector(
+    child: _iconBase(
+      icon,
+      size: size,
+      color: color
+    ),
+    onTap: onTap
+  );
+
+  static Widget iconText({
+    required IconData icon, 
+    required String text, 
+    double iconSize = 30.0,
+    Color iconColor = Colors.black,
+    double textSize = 18.0,
+    TextAlign textAlign = TextAlign.center,
+    bool textSoftWrap = true,
+    TextOverflow textOverflow = TextOverflow.clip,
+    FontWeight textFontWeight = FontWeight.w600,
+    Color textColor = Colors.black,
+    EdgeInsets padding = const EdgeInsets.only(bottom: 10.0),
+    double spacing = 10.0
+  }) => Padding(
+    padding: padding,
+    child: Row(
+      mainAxisAlignment: MainAxisAlignment.start,
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        _iconBase(
+          icon,
+          size: iconSize,
+          color: iconColor
+        ),
+        SizedBox(width: spacing,),
+        constrainedText(text,
+          size: textSize,
+          textAlign: textAlign,
+          softWrap: textSoftWrap,
+          textOverflow: textOverflow,
+          fontWeight: textFontWeight,
+          color: textColor
+        )
+      ],
+    )
+  );
+
+  static Widget _textFormFieldBase({
+    required BuildContext context,
+    TextEditingController? textEditingController,
+    required String label,
+    required String hint,
+    required Function(String?) onSaved,
+    required String? Function(String?) validator,
+    AutovalidateMode? autovalidateMode,
+    bool autofocus = false,
+    String? initialValue,
+    Function()? onTap,
+    Function(String)? onChanged
+  }) => TextFormField(
+    controller: textEditingController,
+    autovalidateMode: autovalidateMode,
+    autofocus: autofocus,
+    initialValue: initialValue,  
+    keyboardType: TextInputType.text,
+    decoration: InputDecoration (
+      icon: const Icon(Icons.folder),
+      hintText: hint,
+      labelText: label,
+    ),
+    validator: validator,
+    onSaved: onSaved,
+    onTap: onTap,
+    onChanged: onChanged,
+  );
+
+  static Widget formTextField({
+    required BuildContext context,
+    TextEditingController? textEditingController,
+    required String label,
+    required String hint,
+    required Function(String?) onSaved,
+    required String? Function(String?) validator,
+    AutovalidateMode? autovalidateMode,
+    bool autofocus = false,
+    String? initialValue,
+    Function()? onTap,
+    Function(String)? onChanged,
+    padding = const EdgeInsets.only(bottom: 10.0),
+  }) => Padding(
+    padding: padding,
+    child: Column(
+      mainAxisAlignment: MainAxisAlignment.start,
+      crossAxisAlignment: CrossAxisAlignment.baseline,
+      textBaseline: TextBaseline.alphabetic,
+      children: [
+        _textFormFieldBase(
+          context: context,
+          textEditingController: textEditingController,
+          label: label,
+          hint: hint,
+          onSaved: onSaved,
+          validator: validator,
+          autovalidateMode: autovalidateMode,
+          autofocus: autofocus,
+          initialValue: initialValue,
+          onTap: onTap,
+          onChanged: onChanged
+        )
+      ],
+    )
+  );  
+
+  static Widget actionsSection(BuildContext context,
+  {
+    required List<Widget> buttons,
+    EdgeInsets padding = const EdgeInsets.only(top: 20.0)
+  }) =>  Padding(
+    padding: padding,
+    child: Row(
+      mainAxisAlignment: MainAxisAlignment.end,
+      mainAxisSize: MainAxisSize.max,
+      children: buttons
+    )
+  );
+
+  static Widget roundedButton(BuildContext context,
+  {
+    required IconData icon,
+    required String text,
+    required Function action,
+    double iconSize = 30.0,
+    Color iconColor = Colors.black,
+    double width = 60.0,
+    double height = 60.0,
+    double textSize = 13.0,
+    FontWeight textFontWeight = FontWeight.w700,
+    double spacing = 5.0
+  }) => Column(
     mainAxisAlignment: MainAxisAlignment.center,
     crossAxisAlignment: CrossAxisAlignment.center,
     children: [
       OutlinedButton(
         onPressed: () => action.call(),
         child: Container(
-          width: buttonSize,
-          height: buttonSize,
+          width: width,
+          height: height,
           alignment: Alignment.center,
           decoration: BoxDecoration(
             shape: BoxShape.circle
           ),
-          child: icon,
+          child: _iconBase(
+            icon,
+            size: iconSize,
+            color: iconColor
+          ),
         ),
         style: OutlinedButton.styleFrom(
           shape: CircleBorder(),
@@ -237,14 +363,14 @@ Widget buildRoundedButton(BuildContext context, Icon icon, String text, Function
         ),
       ),
       Divider(
-        height: 5.0,
+        height: spacing,
         color: Colors.transparent,
       ),
       Text(
         text,
         style: TextStyle(
           fontSize: textSize,
-          fontWeight: FontWeight.w700,
+          fontWeight: textFontWeight,
         ),
       )
     ]

--- a/lib/app/utils/fields.dart
+++ b/lib/app/utils/fields.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
 import 'package:styled_text/styled_text.dart';
 
 class Fields {
@@ -80,7 +79,7 @@ class Fields {
     padding
   );
 
-  static ElevatedButton inPageButton ({
+  static Widget inPageButton ({
     required Function()? onPressed,
     required String text,
     Alignment alignment = Alignment.center,
@@ -222,6 +221,7 @@ class Fields {
 
   static Widget constrainedText(String text,
   {
+    int flex = 1,
     double size = 18.0,
     TextAlign textAlign = TextAlign.start,
     bool softWrap = true,
@@ -229,7 +229,7 @@ class Fields {
     FontWeight fontWeight = FontWeight.w600,
     Color color = Colors.black
   })  => Expanded(
-    flex: 1,
+    flex: flex,
     child: Text(
       text,
       textAlign: textAlign,
@@ -307,6 +307,7 @@ class Fields {
   static Widget _textFormFieldBase({
     required BuildContext context,
     TextEditingController? textEditingController,
+    Icon? icon,
     required String label,
     required String hint,
     required Function(String?) onSaved,
@@ -314,16 +315,18 @@ class Fields {
     AutovalidateMode? autovalidateMode,
     bool autofocus = false,
     String? initialValue,
+    bool obscureText = false,
     Function()? onTap,
     Function(String)? onChanged
   }) => TextFormField(
     controller: textEditingController,
     autovalidateMode: autovalidateMode,
     autofocus: autofocus,
-    initialValue: initialValue,  
+    initialValue: initialValue,
+    obscureText: obscureText,  
     keyboardType: TextInputType.text,
     decoration: InputDecoration (
-      icon: const Icon(Icons.folder),
+      icon: icon,
       hintText: hint,
       labelText: label,
     ),
@@ -336,6 +339,7 @@ class Fields {
   static Widget formTextField({
     required BuildContext context,
     TextEditingController? textEditingController,
+    Icon? icon,
     required String label,
     required String hint,
     required Function(String?) onSaved,
@@ -343,6 +347,7 @@ class Fields {
     AutovalidateMode? autovalidateMode,
     bool autofocus = false,
     String? initialValue,
+    bool obscureText = false,
     Function()? onTap,
     Function(String)? onChanged,
     padding = const EdgeInsets.only(bottom: 10.0),
@@ -356,6 +361,7 @@ class Fields {
         _textFormFieldBase(
           context: context,
           textEditingController: textEditingController,
+          icon: icon,
           label: label,
           hint: hint,
           onSaved: onSaved,
@@ -363,6 +369,7 @@ class Fields {
           autovalidateMode: autovalidateMode,
           autofocus: autofocus,
           initialValue: initialValue,
+          obscureText: obscureText,
           onTap: onTap,
           onChanged: onChanged
         )

--- a/lib/app/utils/fields.dart
+++ b/lib/app/utils/fields.dart
@@ -439,4 +439,32 @@ class Fields {
       )
     ]
   );
+
+  static Container routeBar({ required Widget route })
+    => Container(
+      padding: EdgeInsets.all(10.0),
+      decoration: const BoxDecoration(
+        border: Border(
+          bottom: BorderSide(
+            width: 0.0,
+            color: Colors.transparent,
+            style: BorderStyle.solid
+          ),
+        ),
+        color: Colors.white,
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Expanded(
+            flex: 1,
+            child: Row(
+              children: [
+                Expanded(child: route),
+              ],
+            )
+          ),
+        ],
+      ),
+    ); 
 }

--- a/lib/app/utils/inline_text_styles.dart
+++ b/lib/app/utils/inline_text_styles.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+import 'package:styled_text/styled_text.dart';
+
+class InlineTextStyles {
+  InlineTextStyles._();
+
+  static StyledTextTagBase bold = StyledTextTag(style: const TextStyle(fontWeight: FontWeight.bold));
+
+  static StyledTextTagBase size({double size = 28.0}) => StyledTextTag(style: TextStyle(fontSize: size));
+
+  static StyledTextTagBase color(Color color) => StyledTextTag(style: TextStyle(color: color));
+  
+  static StyledTextTagBase icon(IconData icon, {double? size, Color? color}) => StyledTextIconTag(
+    icon,
+    size: size,
+    color: color
+  );
+}

--- a/lib/app/utils/strings.dart
+++ b/lib/app/utils/strings.dart
@@ -1,30 +1,63 @@
 class Strings {
   Strings._();
 
+  /// Configuration
+  static const String directoryRepositoriesName = 'repositories';
+  static const String databaseConfigurationName = 'config.db';
+
   /// Page titles
   static const String titleApp = 'OuiSync';
   static const String titleRootPage = 'Repositories';
+  static const String titleAddShareFilePage = 'Add file to OuiSync';
 
   static const String rootPath = '/';
 
+  // State messages
+
+  // General
   static const String messageLoadingContents = 'Loading the directory contents...';
-  static const String messageOhOh = 'Oh oh...';
-  static const String messageErrorState = 'Something went wrong <bold>:\\</bold>';
+  static const String messageErrorLoadingContents = 'Oooops!\n(Something went wrong trying to do the thing,'
+  ' sorry about that. Please try again)';
+
+  static const String messageOhOh = '<color>Oh oh...</color> <size><bold>o.0</bold></size>';
+  static const String messageErrorState = 'That did not work as we expected <size><bold>:\\</bold></size>\n'
+  'Would you please try again... ? Thanks!\n\n<size><bold><icon></icon><bold></size>';
+
+  // main_page.dart
+  static const String messageNoRepo = 'Before adding a file, you need to create a repository';
+  static const String messageCreateNewRepo = 'Create a new <bold>repository</bold>,'
+  ' or link to one from a friend using a <bold>repository token</bold>';
   static const String messageNoRepos = 'No repositories found';
   static const String messageEmptyRepo = 'This repository is empty';
   static const String messageEmptyFolder = 'This folder is empty';
+  static const String messageCreateAddNewItem = 'Create a new <bold>folder</bold>, or add a <bold>file</bold>,'
+  ' using <icon></icon>';
+
+  // add_shared_file_page.dart
   static const String messageEmptyFolderStructure = 'Move along, nothing to see here...';
-  static const String messageCreateNewFolderRootToStartStyled = 'Maybe start by creating a new folder using <bold>Actions</bold> <arrow_down></arrow_down>'
-  '\n... or just go ahead and use <bold>/</bold>, we are not your mother';
-  static const String messageCreateNewFolderStyled = 'You can create a new folder using (look down <arrow_down/>)'
+  static const String messageCreateNewFolderRootToStart = 'Maybe start by creating a new <bold>folder</bold>\n'
+  '... or just go ahead and use <size><bold>\/</bold></size>, we are not your mother';
+  static const String messageCreateNewFolder = 'You can create a new <bold>folder</bold> (look down <icon></icon>)'
   '\n... or just drop it here, champ';
 
-  static const String messageCreateNewRepoStyled = 'Create a new <bold>repository</bold>, or link to one from a friend using a <bold>repository token</bold>';
-  static const String messageCreateAddNewItemStyled = 'Create a new <bold>folder</bold>, or add a <bold>file</bold>,'
-  ' using <add_circle></add_circle>';
+  // Dialogs
+
+  static const String titleMovingEntry = 'Moving Entry';
+  static const String messageMovingEntry = 'This function is not availabe when moving an entry';
+
+  static const String titleCreateRepository = 'Create Repository';
+  static const String titleAddRepository = 'Add Repository';
+  static const String titleSettings = 'Settings';
+
+  // Buttons text
+
+  static const String actionCreateRepository = 'Create a Repository';
+  static const String actionAddRepositoryWithToken = 'Add a Shared Repository';
+
+  static const String actionReloadContents = 'Reload';
+
 
   static const String actionNewRepo = 'Create repository';
-
   static const String actionNewFolder = 'Create folder';
   static const String actionNewFile = 'Add file';
 
@@ -33,5 +66,7 @@ class Strings {
   static const String actionPreviewFile = 'Preview file';
   static const String actionShareFile = 'Share file';
   static const String actionDeleteFile = 'Delete file';
+
+  
 
 }

--- a/lib/app/utils/strings.dart
+++ b/lib/app/utils/strings.dart
@@ -1,24 +1,27 @@
 class Strings {
   Strings._();
 
+  /// Page titles
   static const String titleApp = 'OuiSync';
   static const String titleRootPage = 'Repositories';
 
   static const String rootPath = '/';
 
+  static const String messageLoadingContents = 'Loading the directory contents...';
   static const String messageOhOh = 'Oh oh...';
   static const String messageErrorState = 'Something went wrong <bold>:\\</bold>';
   static const String messageNoRepos = 'No repositories found';
   static const String messageEmptyRepo = 'This repository is empty';
   static const String messageEmptyFolder = 'This folder is empty';
   static const String messageEmptyFolderStructure = 'Move along, nothing to see here...';
-  static const String messageCreateNewFolderRootToStartStyled = 'Maybe start by creating a new folder using <bold>Actions</bold> <arrow_down/>'
+  static const String messageCreateNewFolderRootToStartStyled = 'Maybe start by creating a new folder using <bold>Actions</bold> <arrow_down></arrow_down>'
   '\n... or just go ahead and use <bold>/</bold>, we are not your mother';
   static const String messageCreateNewFolderStyled = 'You can create a new folder using (look down <arrow_down/>)'
   '\n... or just drop it here, champ';
 
-  static const String messageCreateNewRepoStyled = 'Create a new repository, or link to one from a friend <arrow_down/>';
-  static const String messageCreateAddNewItemStyled = 'Create a new folder, or add a file, using <bold>Actions</bold> <arrow_down/>';
+  static const String messageCreateNewRepoStyled = 'Create a new <bold>repository</bold>, or link to one from a friend using a <bold>repository token</bold>';
+  static const String messageCreateAddNewItemStyled = 'Create a new <bold>folder</bold>, or add a <bold>file</bold>,'
+  ' using <add_circle></add_circle>';
 
   static const String actionNewRepo = 'Create repository';
 

--- a/lib/app/utils/utils.dart
+++ b/lib/app/utils/utils.dart
@@ -7,6 +7,7 @@ export 'dialogs.dart';
 export 'entry_info.dart';
 export 'fields.dart';
 export 'format.dart';
+export 'inline_text_styles.dart';
 export 'settings.dart';
 export 'spinning_icon.dart';
 export 'strings.dart';

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,7 +7,6 @@ import 'package:path_provider/path_provider.dart';
 
 import 'app/app.dart';
 import 'app/bloc/blocs.dart';
-import 'app/utils/actions.dart';
 import 'app/utils/utils.dart';
 
 Future<void> main() async {
@@ -15,11 +14,9 @@ Future<void> main() async {
 
   Bloc.observer = SimpleBlocObserver();
 
-  Repository? defaultRepository;
-
   final appDir = (await getApplicationSupportDirectory()).path;
-  final repositoriesDir = '$appDir/repositories';
-  final sessionStore = '$appDir/config.db';
+  final repositoriesDir = '$appDir/${Strings.directoryRepositoriesName}';
+  final sessionStore = '$appDir/${Strings.databaseConfigurationName}';
 
   final localRepositoriesList = loadLocalRepositories(repositoriesDir).map((e) => e.substring(0, e.lastIndexOf('.'))).toList();
   final latestRepositoryOrDefaultName = await getLatestRepositoryOrDefault(localRepositoriesList);
@@ -32,16 +29,13 @@ Future<void> main() async {
   );
 
   final session = await Session.open(sessionStore);
-  if (latestRepositoryOrDefaultName.isNotEmpty) {
-   defaultRepository = await Repository.open(session, '$repositoriesDir/$latestRepositoryOrDefaultName.db'); 
-  }
-  
-  runApp(OuiSyncApp(
-    appDir: appDir,
-    repositoriesDir: repositoriesDir,
-    session: session,
-    defaultRepository: defaultRepository,
-    defaultRepositoryName: latestRepositoryOrDefaultName,
+  runApp(MaterialApp(
+    home: OuiSyncApp(
+      session: session,
+      appStorageLocation: appDir,
+      repositoriesLocation: repositoriesDir,
+      defaultRepositoryName: latestRepositoryOrDefaultName,
+    )
   ));
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,6 +21,7 @@ environment:
   sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
+  async: ^2.8.1
   bloc: ^7.2.1
   bloc_test: ^8.1.0
   build_runner: ^2.0.5

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -47,7 +47,7 @@ dependencies:
   receive_sharing_intent: ^1.4.5
   share_plus: ^3.0.4
   shared_preferences: ^2.0.8
-  styled_text: ^3.0.3
+  styled_text: ^4.0.0+1
   url_launcher: ^6.0.6
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,7 +43,7 @@ dependencies:
   ouisync_plugin:
     path: ./ouisync-plugin
   path: ^1.8.0
-  path_provider: ^2.0.5
+  path_provider: ^2.0.8
   receive_sharing_intent: ^1.4.5
   share_plus: ^3.0.4
   shared_preferences: ^2.0.8

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -53,6 +53,8 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  integration_test:
+    sdk: flutter
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec


### PR DESCRIPTION
When waking up the app from an share intent, the repository instance was not available when trying to process the payload.

App initialization was refactored to fix the issue, as well as several other process:

- New class with builder functions for commonly used widgets (fields).
- String constants moved to their own class and updated to maintain consistency (used terms and phrases).
- Constants values extracted and updated.
- Outdated libraries updated and deprecated functions replaced.
- `NavigationBar` class renamed as `CustomNavigationBar` to avoid shadowing issues with other packages.
- Deprecated `ChunkedStreamIterator` (`chunked_stream` plugin) replaced with `ChunkedStreamReader` (`async` plugin).
- Redundand code removed or abstracted to rehusable methods.
- Unused imports removed.

NOTE: This branch was originally called `strings_extraction`, but was later renamed as `android_share_intent_fix` when the issue was discovered while performing the extraction of string constants.