### PR TITLE
Added: no_repositories_state.dart

### DIFF
--- a/lib/app/custom_widgets/custom_widgets.dart
+++ b/lib/app/custom_widgets/custom_widgets.dart
@@ -27,3 +27,4 @@ export 'items/sync_widget.dart';
 
 export 'states/locked_repository_state.dart';
 export 'states/loading_main_page_state.dart';
+export 'states/no_repositories_state.dart';

--- a/lib/app/custom_widgets/dialogs/actions_dialog.dart
+++ b/lib/app/custom_widgets/dialogs/actions_dialog.dart
@@ -36,6 +36,7 @@ class _ActionsDialogState extends State<ActionsDialog> {
             child: LayoutBuilder(
               builder: (BuildContext context, BoxConstraints viewportConstraints) {
                 return SingleChildScrollView(
+                  reverse: true,
                   child: ConstrainedBox(
                     constraints: BoxConstraints(
                       minHeight: viewportConstraints.minHeight 

--- a/lib/app/custom_widgets/dialogs/modal_repo_creation_dialog.dart
+++ b/lib/app/custom_widgets/dialogs/modal_repo_creation_dialog.dart
@@ -24,14 +24,24 @@ class RepositoryCreation extends StatelessWidget {
     return Form(
       key: this.formKey,
       autovalidateMode: AutovalidateMode.onUserInteraction,
-      child: _buildCreateRepositoryWidget(this.context),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        mainAxisAlignment: MainAxisAlignment.center,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          SingleChildScrollView(
+            reverse: true,
+            child: _buildCreateRepositoryWidget(this.context)
+          )
+        ]
+      ),
     );
   }
 
   Widget _buildCreateRepositoryWidget(BuildContext context) {
     return Column(
+      mainAxisSize: MainAxisSize.min,
       mainAxisAlignment: MainAxisAlignment.center,
-      mainAxisSize: MainAxisSize.max,
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         Fields.formTextField(

--- a/lib/app/custom_widgets/states/no_repositories_state.dart
+++ b/lib/app/custom_widgets/states/no_repositories_state.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:ouisync_app/app/cubit/cubits.dart';
+import 'package:ouisync_app/app/utils/utils.dart';
+
+class NoRepositoriesState extends StatelessWidget {
+  const NoRepositoriesState({
+    Key? key,
+    required this.repositoriesCubit,
+    required this.onNewRepositoryPressed,
+    required this.onAddRepositoryPressed
+  }) : super(key: key);
+
+  final RepositoriesCubit repositoriesCubit;
+  final Function(RepositoriesCubit) onNewRepositoryPressed;
+  final Function(RepositoriesCubit) onAddRepositoryPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: SingleChildScrollView(
+        reverse: false,
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            Align(
+              alignment: Alignment.center,
+              child: Fields.inPageMainMessage(Strings.messageNoRepos),
+            ),
+            Dimensions.spacingVertical,
+            Align(
+              alignment: Alignment.center,
+              child: Fields.inPageSecondaryMessage(
+                Strings.messageCreateNewRepo,
+                tags: { Constants.inlineTextBold: InlineTextStyles.bold }
+              )
+            ),
+            Dimensions.spacingVerticalDouble,
+            Dimensions.spacingVertical,
+            Fields.inPageButton(
+              onPressed: () => onNewRepositoryPressed.call(repositoriesCubit),
+              text: Strings.actionCreateRepository,
+              size: Dimensions.sizeInPageButtonLong,
+              autofocus: true
+            ),
+            Dimensions.spacingVerticalDouble,
+            Fields.inPageButton(
+              onPressed: () => onAddRepositoryPressed(repositoriesCubit),
+              text: Strings.actionAddRepositoryWithToken,
+              size: Dimensions.sizeInPageButtonLong,
+            ),
+          ],
+        ),
+      )
+    );
+  }
+}

--- a/lib/app/pages/main_page.dart
+++ b/lib/app/pages/main_page.dart
@@ -394,8 +394,12 @@ class _MainPageState extends State<MainPage>
       NativeChannels.setRepository(repository); 
 
       if (repository == null) {
-        switchMainState(newState:
-          _noRepositoriesState()
+        switchMainState(
+          newState:NoRepositoriesState(
+            repositoriesCubit: BlocProvider.of<RepositoriesCubit>(context),
+            onNewRepositoryPressed: createRepoDialog,
+            onAddRepositoryPressed: addRepoWithTokenDialog
+          )
         );
         return;
       }
@@ -749,38 +753,6 @@ class _MainPageState extends State<MainPage>
           text: Strings.actionReloadContents,
           autofocus: true
         )
-      ],
-    );
-
-    _noRepositoriesState() => Column(
-      mainAxisAlignment: MainAxisAlignment.center,
-      crossAxisAlignment: CrossAxisAlignment.center,
-      children: [
-        Align(
-          alignment: Alignment.center,
-          child: Fields.inPageMainMessage(Strings.messageNoRepos),
-        ),
-        SizedBox(height: 10.0),
-        Align(
-          alignment: Alignment.center,
-          child: Fields.inPageSecondaryMessage(
-            Strings.messageCreateNewRepo,
-            tags: { Constants.inlineTextBold: InlineTextStyles.bold }
-          )
-        ),
-        SizedBox(height: 30.0),
-        Fields.inPageButton(
-          onPressed: () => createRepoDialog(BlocProvider.of<RepositoriesCubit>(context)),
-          text: Strings.actionCreateRepository,
-          size: Dimensions.sizeInPageButtonLong,
-          autofocus: true
-        ),
-        SizedBox(height: 20.0),
-        Fields.inPageButton(
-          onPressed: () => addRepoWithTokenDialog(BlocProvider.of<RepositoriesCubit>(context)),
-          text: Strings.actionAddRepositoryWithToken,
-          size: Dimensions.sizeInPageButtonLong,
-        ),
       ],
     );
 
@@ -1180,11 +1152,7 @@ class _MainPageState extends State<MainPage>
           ),
         );
       }
-    ).then((newRepository) {
-      // if (newRepository.isNotEmpty) { // If a repository is created, the new repository name is returned; otherwise, empty string.
-      //   switchMainState(newState: _repositoryContentBuilder());
-      // }
-    });
+    );
   }
 
   void addRepoWithTokenDialog(cubit) async {
@@ -1256,7 +1224,7 @@ class _MainPageState extends State<MainPage>
             title: Strings.titleSettings,
             dhtStatus: dhtStatus,
           )
-        );;
+        );
       })
     );
   }


### PR DESCRIPTION
Fix #63 : In small screens, when the dialog for creating a repository was open, and the current state correspond to no repositories, a layout overflow was happening (not in the dialog, but the state widget)

To fix this issue, the function that returned a widget for the state used when there was no repositories, was extracted from the main page as a StatelessWidget; a SingleChildScrollView was used to wrap the contents in the state widget, and in the dialog (modal_repo_creation_dialog.dart), the content was wrapped in an extra Column.

Also: unused code removed