### PR TITLE
Issue 106: Create windows installer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,7 @@ android/log
 android/log.bck
 /ios/ouisync/build-dir/
 .vscode/settings.json
+
+# For Windows app publishing (MSIX)
+/installers/
+/certificates/

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -141,6 +141,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.1"
+  cli_dialog:
+    dependency: transitive
+    description:
+      name: cli_dialog
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.5.0"
   cli_util:
     dependency: transitive
     description:
@@ -246,6 +253,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.4"
+  dart_console:
+    dependency: transitive
+    description:
+      name: dart_console
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.0"
   dart_style:
     dependency: transitive
     description:
@@ -402,6 +416,13 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  get_it:
+    dependency: transitive
+    description:
+      name: get_it
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "7.2.0"
   glob:
     dependency: transitive
     description:
@@ -561,6 +582,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.2"
+  msix:
+    dependency: "direct dev"
+    description:
+      name: msix
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.6.0"
   nested:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -76,6 +76,7 @@ dev_dependencies:
   # the vscode plugin:
   # # flutter pub run intl_utils:generate
   intl_utils:  ^2.6.1
+  msix: ^3.5.1
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec
@@ -115,3 +116,21 @@ flutter:
   # see https://flutter.dev/custom-fonts/#from-packages
 flutter_intl:
   enabled: true
+
+msix_config:
+  display_name: OuiSync
+  publisher_name: eQualitie
+  certificate_path: .\certificates\self-signed\CERTIFICATE.pfx
+  certificate_password: _ball$*watch17
+  logo_path: .\assets\OuiSync-App-Icon-1200.png
+  start_menu_icon_path: .\assets\OuiSync-App-Icon-1200.png
+  tile_icon_path: .\assets\OuiSync-App-Icon-1200.png
+  app_installer: #<-- app installer configuration
+    publish_folder_path: .\installers
+    hours_between_update_checks: 0
+    automatic_background_task: true
+    update_blocks_activation: true
+    show_prompt: true
+    force_update_from_any_version: false
+    capabilities: internetClient, internetClientServer, privateNetworkClientServer, removableStorage, documentsLibrary
+  msix_version: 1.0.0.0


### PR DESCRIPTION
Package `msix` dependency, and configuration settings in the `pubspec.yaml` file, added.

A `.msix` installer can be generated, using self-signed certificates.

Close #106 