### PR TITLE
Fix file download/saving cancelation

### DIFF
--- a/lib/app/bloc/directory/directory_bloc.dart
+++ b/lib/app/bloc/directory/directory_bloc.dart
@@ -98,8 +98,6 @@ class DirectoryBloc extends Bloc<DirectoryEvent, DirectoryState> with OuiSyncApp
             length: event.length,
             progress: offset
           ));
-
-          await Future.delayed(const Duration(seconds: 2));
         }
       } catch (e, st) {
         loggy.app('Writing to file ${event.newFilePath} exception', e, st);

--- a/lib/app/bloc/directory/directory_bloc.dart
+++ b/lib/app/bloc/directory/directory_bloc.dart
@@ -79,9 +79,12 @@ class DirectoryBloc extends Bloc<DirectoryEvent, DirectoryState> with OuiSyncApp
       int offset = 0;
       try {
         final stream = event.fileByteStream
-        .takeWhile((element) { 
-          if (_cancelFileWriting.isEmpty) { return true; }
-          return _cancelFileWriting != event.newFilePath;
+        .takeWhile((element) {
+          return _takeWhile(
+            event.repository.handle,
+            event.newFilePath,
+            _repositorySave,
+            _cancelFileWriting);
         });
         
         await for (final buffer in stream) {
@@ -89,16 +92,19 @@ class DirectoryBloc extends Bloc<DirectoryEvent, DirectoryState> with OuiSyncApp
           offset += buffer.length;
 
           emit(WriteToFileInProgress(
+            repository: event.repository,
             path: event.newFilePath,
             fileName: event.fileName,
             length: event.length,
             progress: offset
           ));
+
+          await Future.delayed(const Duration(seconds: 2));
         }
       } catch (e, st) {
         loggy.app('Writing to file ${event.newFilePath} exception', e, st);
         emit(ShowMessage(S.current.messageWritingFileError(event.newFilePath)));
-        emit(WriteToFileDone(path: event.newFilePath));
+        emit(WriteToFileDone(repository: event.repository, path: event.newFilePath));
         return;
       } finally {
         loggy.app('Writing to file ${event.newFilePath} done - closing');
@@ -107,7 +113,7 @@ class DirectoryBloc extends Bloc<DirectoryEvent, DirectoryState> with OuiSyncApp
 
       if (_cancelFileWriting.isEmpty) {
         emit(ShowMessage(S.current.messageWritingFileDone(event.newFilePath)));
-        emit(WriteToFileDone(path: event.newFilePath));
+        emit(WriteToFileDone(repository: event.repository, path: event.newFilePath));
         return;
       }
 
@@ -116,15 +122,20 @@ class DirectoryBloc extends Bloc<DirectoryEvent, DirectoryState> with OuiSyncApp
         _cancelFileWriting = '';
 
         emit(ShowMessage(S.current.messageWritingFileCanceled(event.newFilePath)));
-        emit(WriteToFileDone(path: event.newFilePath));
+        emit(WriteToFileDone(repository: event.repository, path: event.newFilePath));
       }
     }
   }
 
   String _cancelFileWriting = '';
+  Repository? _repositorySave;
   void _onCancelSaveFile(CancelSaveFile event, Emitter<DirectoryState> emit) {
-    loggy.app('Canceling ${event.filePath}');
+    loggy.app('Canceling ${event.filePath} creation');
+
+    _repositorySave = event.repository.handle;
     _cancelFileWriting = event.filePath;
+
+    loggy.app('Cancel creation: repository=${event.repository.name} handle=${event.repository.handle.handle} file=${event.filePath}');
   }
 
   Future<void> _onDownloadFile(DownloadFile event, Emitter<DirectoryState> emit) async {
@@ -201,18 +212,6 @@ class DirectoryBloc extends Bloc<DirectoryEvent, DirectoryState> with OuiSyncApp
     }
   }
 
-  bool _takeWhile(
-    Repository repository, String filePath,
-    Repository? cancelRepository, String cancelFilePath) {
-      loggy.app('Take while: handle=${repository.handle} file=$filePath cancel-repo=${cancelRepository?.handle} cancel-file=$cancelFilePath');
-
-      if (repository != cancelRepository) {
-        return true;
-      }
-
-      return filePath != cancelFilePath;
-  }  
-
   String _cancelFileDownload = '';
   Repository? _repositoryDownload;
   void _onCancelDownloadFile(CancelDownloadFile event, Emitter<DirectoryState> emit) {
@@ -222,6 +221,20 @@ class DirectoryBloc extends Bloc<DirectoryEvent, DirectoryState> with OuiSyncApp
     _cancelFileDownload = event.filePath;
 
     loggy.app('Cancel downloading: repository=${event.repository.name} handle=${event.repository.handle.handle} file=${event.filePath}');
+  }
+
+  bool _takeWhile(
+    Repository repository,
+    String filePath,
+    Repository? cancelRepository,
+    String cancelFilePath) {
+      loggy.app('Take while: handle=${repository.handle} file=$filePath cancel-repo=${cancelRepository?.handle} cancel-file=$cancelFilePath');
+
+      if (repository != cancelRepository) {
+        return true;
+      }
+
+      return filePath != cancelFilePath;
   }
 
   Future<DirectoryState> _createFile(

--- a/lib/app/bloc/directory/directory_bloc.dart
+++ b/lib/app/bloc/directory/directory_bloc.dart
@@ -158,7 +158,8 @@ class DirectoryBloc extends Bloc<DirectoryEvent, DirectoryState> with OuiSyncApp
         if (chunk.length < Constants.bufferSize) {
           emit(DownloadFileDone(
             path: event.originFilePath,
-            devicePath: event.destinationPath));
+            devicePath: event.destinationPath,
+            result: DownloadFileResult.done));
           break;
         }
       }
@@ -166,7 +167,10 @@ class DirectoryBloc extends Bloc<DirectoryEvent, DirectoryState> with OuiSyncApp
       loggy.app('Download file ${event.originFilePath} exception', e, st);
 
       emit(ShowMessage(S.current.messageDownloadingFileError(event.originFilePath)));
-      emit(DownloadFileFail(path: event.originFilePath));
+      emit(DownloadFileDone(
+        path: event.originFilePath,
+        devicePath: event.destinationPath,
+        result: DownloadFileResult.failed));
 
       return;
     } finally {
@@ -185,7 +189,10 @@ class DirectoryBloc extends Bloc<DirectoryEvent, DirectoryState> with OuiSyncApp
       loggy.app('${event.originFilePath} download canceled by the user');
       emit(ShowMessage(S.current.messageDownloadingFileCanceled(event.originFilePath)));
 
-      emit(DownloadFileCancel(path: event.originFilePath));
+      emit(DownloadFileDone(
+        path: event.originFilePath,
+        devicePath: event.destinationPath,
+        result: DownloadFileResult.canceled));
     }
   }
 

--- a/lib/app/bloc/directory/directory_event.dart
+++ b/lib/app/bloc/directory/directory_event.dart
@@ -98,13 +98,15 @@ class SaveFile extends DirectoryEvent {
 
 class CancelSaveFile extends DirectoryEvent {
   const CancelSaveFile({
+    required this.repository,
     required this.filePath
   });
 
+  final RepoState repository;
   final String filePath;
 
   @override
-  List<Object?> get props => [ filePath ];
+  List<Object?> get props => [ repository, filePath ];
 }
 
 class DownloadFile extends DirectoryEvent {

--- a/lib/app/bloc/directory/directory_event.dart
+++ b/lib/app/bloc/directory/directory_event.dart
@@ -128,13 +128,15 @@ class DownloadFile extends DirectoryEvent {
 
 class CancelDownloadFile extends DirectoryEvent {
   const CancelDownloadFile({
+    required this.repository,
     required this.filePath
   });
 
+  final RepoState repository;
   final String filePath;
 
   @override
-  List<Object?> get props => [ filePath ];
+  List<Object?> get props => [ repository, filePath ];
 }
 
 class MoveEntry extends DirectoryEvent {

--- a/lib/app/bloc/directory/directory_state.dart
+++ b/lib/app/bloc/directory/directory_state.dart
@@ -8,6 +8,12 @@ abstract class DirectoryState extends Equatable {
   List<Object?> get props => [];
 }
 
+enum DownloadFileResult {
+  done,
+  canceled,
+  failed
+}
+
 class DirectoryInitial extends DirectoryState {}
 
 class CreateFileDone extends DirectoryState {
@@ -98,31 +104,15 @@ class DownloadFileDone extends DirectoryState {
   const DownloadFileDone({ 
     required this.path,
     required this.devicePath,
+    required this.result
   });
 
   final String path;
   final String devicePath;
+  final DownloadFileResult result;
 
   @override
-  List<Object> get props => [ path, devicePath ];
-}
-
-class DownloadFileCancel extends DirectoryState {
-  const DownloadFileCancel({ required this.path });
-
-  final String path;
-
-  @override
-  List<Object> get props => [ path ];
-}
-
-class DownloadFileFail extends DirectoryState {
-  const DownloadFileFail({ required this.path });
-
-  final String path;
-
-  @override
-  List<Object> get props => [ path ];
+  List<Object> get props => [ path, devicePath, result ];
 }
 
 class DirectoryLoadInProgress extends DirectoryState {

--- a/lib/app/bloc/directory/directory_state.dart
+++ b/lib/app/bloc/directory/directory_state.dart
@@ -1,6 +1,8 @@
 import 'package:equatable/equatable.dart';
 import 'package:ouisync_plugin/ouisync_plugin.dart';
 
+import '../../models/repo_state.dart';
+
 abstract class DirectoryState extends Equatable {
   const DirectoryState();
 
@@ -80,12 +82,14 @@ class WriteToFileDone extends DirectoryState {
 
 class DownloadFileInProgress extends DirectoryState {
   const DownloadFileInProgress({
+    required this.repository,
     required this.path,
     required this.fileName,
     required this.length,
     required this.progress
   });
 
+  final RepoState repository;
   final String path;
   final String fileName;
   final int length;
@@ -93,6 +97,7 @@ class DownloadFileInProgress extends DirectoryState {
 
   @override
   List<Object> get props => [
+    repository,
     path,
     fileName,
     length,
@@ -102,17 +107,19 @@ class DownloadFileInProgress extends DirectoryState {
 
 class DownloadFileDone extends DirectoryState {
   const DownloadFileDone({ 
+    required this.repository,
     required this.path,
     required this.devicePath,
     required this.result
   });
 
+  final RepoState repository;
   final String path;
   final String devicePath;
   final DownloadFileResult result;
 
   @override
-  List<Object> get props => [ path, devicePath, result ];
+  List<Object> get props => [ repository, path, devicePath, result ];
 }
 
 class DirectoryLoadInProgress extends DirectoryState {

--- a/lib/app/bloc/directory/directory_state.dart
+++ b/lib/app/bloc/directory/directory_state.dart
@@ -51,12 +51,14 @@ class ShowMessage extends DirectoryState {
 
 class WriteToFileInProgress extends DirectoryState {
   const WriteToFileInProgress({
+    required this.repository,
     required this.path,
     required this.fileName,
     required this.length,
     required this.progress
   });
 
+  final RepoState repository;
   final String path;
   final String fileName;
   final int length;
@@ -64,6 +66,7 @@ class WriteToFileInProgress extends DirectoryState {
 
   @override
   List<Object> get props => [
+    repository,
     path,
     fileName,
     length,
@@ -72,12 +75,16 @@ class WriteToFileInProgress extends DirectoryState {
 }
 
 class WriteToFileDone extends DirectoryState {
-  const WriteToFileDone({ required this.path });
+  const WriteToFileDone({
+    required this.repository,
+    required this.path
+  });
 
+  final RepoState repository;
   final String path;
 
   @override
-  List<Object> get props => [ path ];
+  List<Object> get props => [ repository, path ];
 }
 
 class DownloadFileInProgress extends DirectoryState {

--- a/lib/app/models/main_state.dart
+++ b/lib/app/models/main_state.dart
@@ -1,8 +1,7 @@
 import 'package:ouisync_plugin/ouisync_plugin.dart';
 
-import '../models/models.dart';
-import '../models/repo_state.dart';
 import '../models/folder_state.dart';
+import '../models/repo_state.dart';
 import '../utils/loggers/ouisync_app_logger.dart';
 
 class MainState with OuiSyncAppLogger {

--- a/lib/app/pages/main_page.dart
+++ b/lib/app/pages/main_page.dart
@@ -312,8 +312,6 @@ class _MainPageState extends State<MainPage>
         state is WriteToFileDone ||
         state is DownloadFileInProgress ||
         state is DownloadFileDone ||
-        state is DownloadFileCancel ||
-        state is DownloadFileFail ||
         state is ShowMessage);
       },
       builder: (context, state) {

--- a/lib/app/pages/main_page.dart
+++ b/lib/app/pages/main_page.dart
@@ -423,6 +423,7 @@ class _MainPageState extends State<MainPage>
             };
 
             final listItem = ListItem (
+              repository: _mainState.currentRepo!,
               itemData: item,
               mainAction: actionByType,
               filePopupMenu: _popupMenu(repository: repository, data: item),

--- a/lib/app/widgets/animated/file_icon_animated.dart
+++ b/lib/app/widgets/animated/file_icon_animated.dart
@@ -25,9 +25,7 @@ class FileIconAnimated
     return BlocBuilder<DirectoryBloc, DirectoryState>(
       buildWhen: (previous, current) {
         if (current is DownloadFileInProgress ||
-            current is DownloadFileDone ||
-            current is DownloadFileFail ||
-            current is DownloadFileCancel) {
+            current is DownloadFileDone) {
               return _isCurrentFile(current);}
 
         return false;
@@ -96,23 +94,21 @@ class FileIconAnimated
       }
 
       if (state is DownloadFileDone) {
-        _destinationPath = state.devicePath;
+        IconData iconData;
+        switch (state.result) {
+          case DownloadFileResult.done:
+            _destinationPath = state.devicePath;
+            iconData = Icons.download_done_rounded;
+            break;
+          case DownloadFileResult.canceled:
+            iconData = Icons.file_download_off;
+            break;
+          case DownloadFileResult.failed:
+            iconData = Icons.cancel;
+            break;
+        }
 
-        return const Icon(
-          Icons.download_done_rounded,
-          size: Dimensions.sizeIconAverage);
-      }
-
-      if (state is DownloadFileCancel) {
-        return const Icon(
-          Icons.file_download_off,
-          size: Dimensions.sizeIconAverage);
-      }
-
-      if (state is DownloadFileFail) {
-        return const Icon(
-          Icons.cancel,
-          size: Dimensions.sizeIconAverage);
+        return Icon(iconData);
       }
     }
 
@@ -132,14 +128,6 @@ class FileIconAnimated
     }
 
     if (state is DownloadFileDone) {
-      return state.path;
-    }
-
-    if (state is DownloadFileCancel) {
-      return state.path;
-    }
-
-    if (state is DownloadFileFail) {
       return state.path;
     }
 

--- a/lib/app/widgets/animated/file_icon_animated.dart
+++ b/lib/app/widgets/animated/file_icon_animated.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:ouisync_plugin/ouisync_plugin.dart';
 import 'package:percent_indicator/circular_percent_indicator.dart';
 
 import '../../../generated/l10n.dart';
@@ -11,10 +12,12 @@ class FileIconAnimated
   extends StatelessWidget
   with OuiSyncAppLogger {
   FileIconAnimated({
+    required this.repository,
+    required this.path,
     Key? key,
-    required this.path
   }) : super(key: key);
 
+  final RepoState repository;
   final String path;
 
   String? _destinationPath;
@@ -46,7 +49,9 @@ class FileIconAnimated
 
     if (_downloading) {
       BlocProvider.of<DirectoryBloc>(context).add(
-        CancelDownloadFile(filePath: _getPathFromState(state)));
+        CancelDownloadFile(
+          repository: repository,
+          filePath: _getPathFromState(state)));
     }
   }
 
@@ -118,8 +123,25 @@ class FileIconAnimated
   }
 
   bool _isCurrentFile (DirectoryState state) {
+    final originRepository = _getRepositoryFromState(state);
+    if (originRepository != repository.handle) {
+      return false;
+    }
+
     final originPath = _getPathFromState(state);
     return originPath == path;
+  }
+
+  Repository? _getRepositoryFromState(DirectoryState state) {
+    if (state is DownloadFileInProgress) {
+      return state.repository.handle;
+    }
+
+    if (state is DownloadFileDone) {
+      return state.repository.handle;
+    }
+
+    return null;
   }
 
   String _getPathFromState(DirectoryState state) {

--- a/lib/app/widgets/items/list_item.dart
+++ b/lib/app/widgets/items/list_item.dart
@@ -54,7 +54,7 @@ class ListItem extends StatelessWidget {
           flex: 9,
           child: Padding(
             padding: Dimensions.paddingItem,
-            child: FileDescription(fileData: itemData))),
+            child: FileDescription(repository: repository, fileData: itemData))),
         _getFileAction(),
       ],
     );

--- a/lib/app/widgets/items/list_item.dart
+++ b/lib/app/widgets/items/list_item.dart
@@ -1,17 +1,20 @@
 import 'package:flutter/material.dart';
 
 import '../../models/models.dart';
+import '../../models/repo_state.dart';
 import '../../utils/utils.dart';
 import '../widgets.dart';
 
 class ListItem extends StatelessWidget {
   const ListItem({
+    required this.repository,
     required this.itemData,
     required this.mainAction,
     required this.filePopupMenu,
     required this.folderDotsAction,
   });
 
+  final RepoState repository;
   final BaseItem itemData;
   final Function mainAction;
   final PopupMenuButton<dynamic>? filePopupMenu;
@@ -46,7 +49,7 @@ class ListItem extends StatelessWidget {
       children: <Widget>[
         Expanded(
           flex: 1,
-          child: FileIconAnimated(path: itemData.path)),
+          child: FileIconAnimated(repository: repository, path: itemData.path)),
         Expanded(
           flex: 9,
           child: Padding(


### PR DESCRIPTION
When canceling saving or downloading of a file, the validation to update the state of the app was faulty.

It was only using the file full path, which caused problems in cases in which the same file was being saved/downloaded in more than one repository at the time.

Now both the repository and the file full path are used for the validations related to the canceling operations, as well as the related app/widgets state updates.