### PR TITLE
Repo share link UI updates

### DIFF
--- a/lib/app/utils/constants.dart
+++ b/lib/app/utils/constants.dart
@@ -11,6 +11,8 @@ class Constants{
 
   static const int bufferSize = 64000;
 
+  static const int maxCharacterRepoTokenForDisplay = 8;
+
   /// In-line text style names
 
   static const String inlineTextBold = 'bold';

--- a/lib/app/utils/constants.dart
+++ b/lib/app/utils/constants.dart
@@ -12,6 +12,7 @@ class Constants{
   static const int bufferSize = 64000;
 
   static const int maxCharacterRepoTokenForDisplay = 8;
+  static const String ouisyncUrl = 'https://ouisync.net/';
 
   /// In-line text style names
 

--- a/lib/app/utils/dimensions.dart
+++ b/lib/app/utils/dimensions.dart
@@ -42,6 +42,8 @@ class Dimensions {
   static const EdgeInsets paddingFormTextField = EdgeInsets.only(bottom: 10.0);
   static const EdgeInsets paddingActionsSection = EdgeInsets.only(top: 20.0);
   static const EdgeInsets paddingActionBox = EdgeInsets.all(5.0);
+  static const EdgeInsets paddingActionBoxTop = EdgeInsets.only(top: 10.0, bottom: 5.0);
+  static const EdgeInsets paddingActionBoxRight = EdgeInsets.only(right: 5.0);
   static const EdgeInsets paddingListItem = EdgeInsets.fromLTRB(8.0, 10.0, 2.0, 10.0) ;
   static const EdgeInsets paddingItem = EdgeInsets.only(left: 10.0);
   static const EdgeInsets paddingItemBox = EdgeInsets.only(left: 10.0, top: 5.0, bottom: 5.0);

--- a/lib/app/utils/fields.dart
+++ b/lib/app/utils/fields.dart
@@ -1,10 +1,8 @@
-import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:flutter/material.dart';
-import 'package:ouisync_app/app/utils/utils.dart';
-import 'package:styled_text/styled_text.dart';
 import 'package:badges/badges.dart';
+import 'package:flutter/material.dart';
+import 'package:styled_text/styled_text.dart';
 
-import '../cubits/upgrade_exists.dart';
+import 'utils.dart';
 
 class Fields {
   Fields._();
@@ -305,7 +303,8 @@ class Fields {
     bool softWrap = true,
     double fontSize = Dimensions.fontAverage,
     FontWeight fontWeight = FontWeight.normal,
-    Color color = Colors.black
+    Color color = Colors.black,
+    int maxLines = 1
   })  => Expanded(
     flex: flex,
     child: Text(
@@ -313,6 +312,7 @@ class Fields {
       textAlign: textAlign,
       softWrap: softWrap,
       overflow: textOverflow,
+      maxLines: maxLines,
       style: TextStyle(
         fontSize: fontSize,
         fontWeight: fontWeight,

--- a/lib/app/widgets/dialogs/modal_add_repo_token_dialog.dart
+++ b/lib/app/widgets/dialogs/modal_add_repo_token_dialog.dart
@@ -99,7 +99,7 @@ class _AddRepositoryWithTokenState extends State<AddRepositoryWithToken> with Ou
         Fields.formTextField(
           context: context,
           textEditingController: _tokenController,
-          label: S.current.labelRepositoryToken,
+          label: S.current.labelRepositoryLink,
           hint: S.current.messageRepositoryToken,
           onSaved: (value) {},
           validator: _repositoryTokenValidator,

--- a/lib/app/widgets/dialogs/modal_share_repository_bottom_sheet.dart
+++ b/lib/app/widgets/dialogs/modal_share_repository_bottom_sheet.dart
@@ -76,7 +76,7 @@ class _ShareRepositoryState extends State<ShareRepository>
         _accessMode = null;
 
         _shareToken = null;
-        _displayToken = S.current.messageWaitingAccesMode;
+        _displayToken = Constants.ouisyncUrl;
       });
 
       return;
@@ -140,12 +140,12 @@ class _ShareRepositoryState extends State<ShareRepository>
               mainAxisSize: MainAxisSize.min,
               children: [
                 Fields.constrainedText(
-                  _displayToken ?? S.current.messageWaitingAccesMode,
+                  _displayToken ?? Constants.ouisyncUrl,
                   flex: 0,
                   softWrap: true,
                   maxLines: 2,
                   textOverflow: TextOverflow.fade,
-                  color: Colors.black),],),),
+                  color: _shareToken != null ? Colors.black : Colors.black54),],),),
           _buildShareActions()
         ]));
 

--- a/lib/app/widgets/selectors/access_mode_selector.dart
+++ b/lib/app/widgets/selectors/access_mode_selector.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+import 'package:ouisync_plugin/ouisync_plugin.dart';
+
+import '../../../generated/l10n.dart';
+import '../../utils/loggers/ouisync_app_logger.dart';
+import '../../utils/utils.dart';
+
+class AccessModeSelector extends StatefulWidget {
+  const AccessModeSelector({
+    required this.accessModes,
+    required this.onChanged,
+  });
+
+  final List<AccessMode> accessModes;
+  final Future<void> Function(AccessMode?) onChanged;
+
+  @override
+  State<AccessModeSelector> createState() => _AccessModeSelectorState();
+}
+
+class _AccessModeSelectorState extends State<AccessModeSelector>  with OuiSyncAppLogger {
+  final Map<AccessMode, String> accessModeDescriptions = {
+    AccessMode.blind: S.current.messageBlindReplicaExplanation,
+    AccessMode.read: S.current.messageReadReplicaExplanation,
+    AccessMode.write: S.current.messageWriteReplicaExplanation
+  };
+
+  AccessMode? _selectedMode;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: Dimensions.paddingActionBoxTop,
+      decoration: const BoxDecoration(
+        borderRadius: BorderRadius.all(Radius.circular(Dimensions.radiusSmall)),
+        color: Constants.inputBackgroundColor
+      ),
+      child: _buildModeSelector());
+  }
+
+  Widget _buildModeSelector() {
+    return Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: Dimensions.paddingItem,
+            child: Row(children: [Fields.constrainedText(
+              S.current.labelSetPermission,
+              fontSize: Dimensions.fontMicro,
+              fontWeight: FontWeight.normal,
+              color: Constants.inputLabelForeColor)])),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: _buildAccessModeOptions(),)
+        ],);
+  }
+
+  List<Widget> _buildAccessModeOptions() {
+    return widget.accessModes.map((mode) =>
+      Expanded(child: RadioListTile(
+        title: Text(mode.name,
+          style: const TextStyle(
+            fontSize: Dimensions.fontAverage,
+          ),),
+        toggleable: true,
+        dense: true,
+        contentPadding: const EdgeInsets.all(0.0),
+        visualDensity: VisualDensity.compact,
+        value: mode,
+        groupValue: _selectedMode,
+        onChanged: (current) async {
+          loggy.app('Access mode: $current');
+
+          if (current == null) {
+            setState(() => _selectedMode = null);
+            await widget.onChanged(null);
+
+            return;
+          }
+
+          setState(() => _selectedMode = current as AccessMode);
+          await widget.onChanged(current as AccessMode);
+        },
+      ))).toList();
+  }
+}

--- a/lib/app/widgets/widgets.dart
+++ b/lib/app/widgets/widgets.dart
@@ -31,6 +31,7 @@ export 'items/labeled_switch.dart';
 export 'items/list_item.dart';
 
 export 'selectors/access_mode_dropddown_menu.dart';
+export 'selectors/access_mode_selector.dart';
 
 export 'states/error_state.dart';
 export 'states/loading_main_page_state.dart';

--- a/lib/generated/intl/messages_en.dart
+++ b/lib/generated/intl/messages_en.dart
@@ -123,6 +123,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("BitTorrent DHT: "),
         "labelConnectedPeers":
             MessageLookupByLibrary.simpleMessage("Connected peers: "),
+        "labelCopyLink": MessageLookupByLibrary.simpleMessage("Copy link"),
         "labelDestination": MessageLookupByLibrary.simpleMessage("Destination"),
         "labelDownloadedTo":
             MessageLookupByLibrary.simpleMessage("Downloaded to:"),
@@ -144,6 +145,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "labelSize": MessageLookupByLibrary.simpleMessage("Size: "),
         "labelSyncStatus":
             MessageLookupByLibrary.simpleMessage("Sync Status: "),
+        "labelTokenLink":
+            MessageLookupByLibrary.simpleMessage("Repository share link"),
         "labelTypePassword":
             MessageLookupByLibrary.simpleMessage("Type password: "),
         "labelUseExternalStorage":
@@ -273,12 +276,16 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Paste the token here"),
         "messageSaveToLocation": MessageLookupByLibrary.simpleMessage(
             "Save the file to this folder"),
+        "messageSelectAccessMode": MessageLookupByLibrary.simpleMessage(
+            "Select a permission to create a share link"),
         "messageSelectLocation":
             MessageLookupByLibrary.simpleMessage("Select the location"),
         "messageTokenCopiedToClipboard": MessageLookupByLibrary.simpleMessage(
             "Repository token copied to the clipboard."),
         "messageUnlockRepository":
             MessageLookupByLibrary.simpleMessage("Enter password to unlock"),
+        "messageWaitingAccesMode": MessageLookupByLibrary.simpleMessage(
+            "Waiting for permission level"),
         "messageWriteReplicaExplanation": MessageLookupByLibrary.simpleMessage(
             "Full access. Your peer can read and write"),
         "messageWritingFileCanceled": m12,

--- a/lib/generated/intl/messages_en.dart
+++ b/lib/generated/intl/messages_en.dart
@@ -134,7 +134,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "labelPassword": MessageLookupByLibrary.simpleMessage("Password: "),
         "labelRenameRepository":
             MessageLookupByLibrary.simpleMessage("Enter the new name: "),
-        "labelRepositoryToken": MessageLookupByLibrary.simpleMessage("Token: "),
+        "labelRepositoryLink":
+            MessageLookupByLibrary.simpleMessage("Repository link: "),
         "labelRetypePassword":
             MessageLookupByLibrary.simpleMessage("Retype password: "),
         "labelSelectRepository":
@@ -164,7 +165,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "messageBackgroundNotificationAndroid":
             MessageLookupByLibrary.simpleMessage("OuiSync is running"),
         "messageBlindReplicaExplanation": MessageLookupByLibrary.simpleMessage(
-            "Your peer can not write nor read the contents"),
+            "Your peer cannot write nor read the contents"),
         "messageBlindRepository": MessageLookupByLibrary.simpleMessage(
             "This repository is a blind replica."),
         "messageBlindRepositoryContent": MessageLookupByLibrary.simpleMessage(
@@ -256,7 +257,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "messageReadOnlyContents": MessageLookupByLibrary.simpleMessage(
             "This repository is <bold>read-only</bold>."),
         "messageReadReplicaExplanation": MessageLookupByLibrary.simpleMessage(
-            "Can not be modified, just access the contents"),
+            "Cannot be modified, just access the contents"),
         "messageRenameFile":
             MessageLookupByLibrary.simpleMessage("Rename file"),
         "messageRenameFolder":
@@ -273,7 +274,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Repository password"),
         "messageRepositorySuggestedName": m11,
         "messageRepositoryToken":
-            MessageLookupByLibrary.simpleMessage("Paste the token here"),
+            MessageLookupByLibrary.simpleMessage("Paste the link here"),
         "messageSaveToLocation": MessageLookupByLibrary.simpleMessage(
             "Save the file to this folder"),
         "messageSelectAccessMode": MessageLookupByLibrary.simpleMessage(

--- a/lib/generated/intl/messages_en.dart
+++ b/lib/generated/intl/messages_en.dart
@@ -285,8 +285,6 @@ class MessageLookup extends MessageLookupByLibrary {
             "Repository token copied to the clipboard."),
         "messageUnlockRepository":
             MessageLookupByLibrary.simpleMessage("Enter password to unlock"),
-        "messageWaitingAccesMode": MessageLookupByLibrary.simpleMessage(
-            "Waiting for permission level"),
         "messageWriteReplicaExplanation": MessageLookupByLibrary.simpleMessage(
             "Full access. Your peer can read and write"),
         "messageWritingFileCanceled": m12,

--- a/lib/generated/intl/messages_es.dart
+++ b/lib/generated/intl/messages_es.dart
@@ -137,7 +137,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "labelPassword": MessageLookupByLibrary.simpleMessage("Clave: "),
         "labelRenameRepository":
             MessageLookupByLibrary.simpleMessage("Ingrese el nuevo nombre"),
-        "labelRepositoryToken": MessageLookupByLibrary.simpleMessage("Token: "),
+        "labelRepositoryLink":
+            MessageLookupByLibrary.simpleMessage("Link del repositorio: "),
         "labelRetypePassword":
             MessageLookupByLibrary.simpleMessage("Repita la clave: "),
         "labelSelectRepository":
@@ -274,7 +275,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Clave del repositorio"),
         "messageRepositorySuggestedName": m11,
         "messageRepositoryToken":
-            MessageLookupByLibrary.simpleMessage("Pegue el token aquí"),
+            MessageLookupByLibrary.simpleMessage("Pegue el link aquí"),
         "messageSaveToLocation": MessageLookupByLibrary.simpleMessage(
             "Guardar el archivo en este directorio"),
         "messageSelectAccessMode": MessageLookupByLibrary.simpleMessage(

--- a/lib/generated/intl/messages_es.dart
+++ b/lib/generated/intl/messages_es.dart
@@ -126,6 +126,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("BitTorrent DHT"),
         "labelConnectedPeers":
             MessageLookupByLibrary.simpleMessage("Compañeras conectadas: "),
+        "labelCopyLink": MessageLookupByLibrary.simpleMessage("Copia el link"),
         "labelDestination": MessageLookupByLibrary.simpleMessage("Destino"),
         "labelDownloadedTo":
             MessageLookupByLibrary.simpleMessage("Descargado en:"),
@@ -148,6 +149,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "labelSize": MessageLookupByLibrary.simpleMessage("Tamaño: "),
         "labelSyncStatus": MessageLookupByLibrary.simpleMessage(
             "Estado de la sincronización: "),
+        "labelTokenLink":
+            MessageLookupByLibrary.simpleMessage("Link del repositorio"),
         "labelTypePassword":
             MessageLookupByLibrary.simpleMessage("Ingrese la clave: "),
         "labelUseExternalStorage":
@@ -274,12 +277,16 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Pegue el token aquí"),
         "messageSaveToLocation": MessageLookupByLibrary.simpleMessage(
             "Guardar el archivo en este directorio"),
+        "messageSelectAccessMode": MessageLookupByLibrary.simpleMessage(
+            "Escoge el nivel de acceso para crear el link para compartir"),
         "messageSelectLocation":
             MessageLookupByLibrary.simpleMessage("Seleccione el lugar"),
         "messageTokenCopiedToClipboard": MessageLookupByLibrary.simpleMessage(
             "Token de repositorio copiado al portapapeles"),
         "messageUnlockRepository": MessageLookupByLibrary.simpleMessage(
             "Ingrese la clave para abrir el repositorio"),
+        "messageWaitingAccesMode": MessageLookupByLibrary.simpleMessage(
+            "Esperando por el nivel de accesso"),
         "messageWriteReplicaExplanation": MessageLookupByLibrary.simpleMessage(
             "Aceso total. Tu colega puede leer y modificar"),
         "messageWritingFileCanceled": m12,

--- a/lib/generated/intl/messages_es.dart
+++ b/lib/generated/intl/messages_es.dart
@@ -286,8 +286,6 @@ class MessageLookup extends MessageLookupByLibrary {
             "Token de repositorio copiado al portapapeles"),
         "messageUnlockRepository": MessageLookupByLibrary.simpleMessage(
             "Ingrese la clave para abrir el repositorio"),
-        "messageWaitingAccesMode": MessageLookupByLibrary.simpleMessage(
-            "Esperando por el nivel de accesso"),
         "messageWriteReplicaExplanation": MessageLookupByLibrary.simpleMessage(
             "Aceso total. Tu colega puede leer y modificar"),
         "messageWritingFileCanceled": m12,

--- a/lib/generated/l10n.dart
+++ b/lib/generated/l10n.dart
@@ -660,20 +660,20 @@ class S {
     );
   }
 
-  /// `Your peer can not write nor read the contents`
+  /// `Your peer cannot write nor read the contents`
   String get messageBlindReplicaExplanation {
     return Intl.message(
-      'Your peer can not write nor read the contents',
+      'Your peer cannot write nor read the contents',
       name: 'messageBlindReplicaExplanation',
       desc: '',
       args: [],
     );
   }
 
-  /// `Can not be modified, just access the contents`
+  /// `Cannot be modified, just access the contents`
   String get messageReadReplicaExplanation {
     return Intl.message(
-      'Can not be modified, just access the contents',
+      'Cannot be modified, just access the contents',
       name: 'messageReadReplicaExplanation',
       desc: '',
       args: [],

--- a/lib/generated/l10n.dart
+++ b/lib/generated/l10n.dart
@@ -1290,16 +1290,6 @@ class S {
     );
   }
 
-  /// `Waiting for permission level`
-  String get messageWaitingAccesMode {
-    return Intl.message(
-      'Waiting for permission level',
-      name: 'messageWaitingAccesMode',
-      desc: '',
-      args: [],
-    );
-  }
-
   /// `{name}`
   String replacementName(Object name) {
     return Intl.message(

--- a/lib/generated/l10n.dart
+++ b/lib/generated/l10n.dart
@@ -310,11 +310,11 @@ class S {
     );
   }
 
-  /// `Token: `
-  String get labelRepositoryToken {
+  /// `Repository link: `
+  String get labelRepositoryLink {
     return Intl.message(
-      'Token: ',
-      name: 'labelRepositoryToken',
+      'Repository link: ',
+      name: 'labelRepositoryLink',
       desc: '',
       args: [],
     );
@@ -880,10 +880,10 @@ class S {
     );
   }
 
-  /// `Paste the token here`
+  /// `Paste the link here`
   String get messageRepositoryToken {
     return Intl.message(
-      'Paste the token here',
+      'Paste the link here',
       name: 'messageRepositoryToken',
       desc: '',
       args: [],

--- a/lib/generated/l10n.dart
+++ b/lib/generated/l10n.dart
@@ -500,6 +500,26 @@ class S {
     );
   }
 
+  /// `Repository share link`
+  String get labelTokenLink {
+    return Intl.message(
+      'Repository share link',
+      name: 'labelTokenLink',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `Copy link`
+  String get labelCopyLink {
+    return Intl.message(
+      'Copy link',
+      name: 'labelCopyLink',
+      desc: '',
+      args: [],
+    );
+  }
+
   /// `Share link`
   String get labelShareLink {
     return Intl.message(
@@ -1255,6 +1275,26 @@ class S {
     return Intl.message(
       'Shortly the OS will ask you for permission to execute this app in the background.\n\nThis is required in order to keep syncing while the app is not in the foreground',
       name: 'messageBackgroundAndroidPermissions',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `Select a permission to create a share link`
+  String get messageSelectAccessMode {
+    return Intl.message(
+      'Select a permission to create a share link',
+      name: 'messageSelectAccessMode',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `Waiting for permission level`
+  String get messageWaitingAccesMode {
+    return Intl.message(
+      'Waiting for permission level',
+      name: 'messageWaitingAccesMode',
       desc: '',
       args: [],
     );

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -67,8 +67,8 @@
     "messageDownloadingFileError":"{name} - download failed",
     "messageErrorEntryNotFound":"entry not found",
 
-    "messageBlindReplicaExplanation":"Your peer can not write nor read the contents",
-    "messageReadReplicaExplanation":"Can not be modified, just access the contents",
+    "messageBlindReplicaExplanation":"Your peer cannot write nor read the contents",
+    "messageReadReplicaExplanation":"Cannot be modified, just access the contents",
     "messageWriteReplicaExplanation":"Full access. Your peer can read and write",
 
     "messageNoRepo":"Before adding a <bold>file</bold>, you need to create a <bold>repository</bold>",

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -47,6 +47,8 @@
     "labelDownloadedTo":"Downloaded to:",
 
     "labelSetPermission":"Set permission",
+    "labelTokenLink":"Repository share link",
+    "labelCopyLink":"Copy link",
     "labelShareLink":"Share link",
 
     "messageLoadingDefault":"Loading…",
@@ -133,6 +135,9 @@
 
     "messageBackgroundNotificationAndroid": "OuiSync is running",
     "messageBackgroundAndroidPermissions": "Shortly the OS will ask you for permission to execute this app in the background.\n\nThis is required in order to keep syncing while the app is not in the foreground",
+
+    "messageSelectAccessMode": "Select a permission to create a share link",
+    "messageWaitingAccesMode":"Waiting for permission level",
 
     "replacementName":"{name}",
     "replacementPath":"{path}",

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -27,7 +27,7 @@
     "typeFolder":"Folder",
     "typeFile":"File",
 
-    "labelRepositoryToken":"Token: ",
+    "labelRepositoryLink":"Repository link: ",
     "labelName":"Name: ",
     "labelNewName":"New name: ",
     "labelLocation":"Location: ",
@@ -91,7 +91,7 @@
 
     "messageRepositoryAlreadyExist":"This repository already exists in the app under the name \"{name}\".",
     "messageMovingEntry":"This function is not available when moving an entry.",
-    "messageRepositoryToken":"Paste the token here",
+    "messageRepositoryToken":"Paste the link here",
     "messageRepositoryName":"Give the repository a name",
     "messageRepositoryNewName":"Repository new name",
     "messageRepositoryAccessMode":"Access mode granted: {access}",

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -137,7 +137,6 @@
     "messageBackgroundAndroidPermissions": "Shortly the OS will ask you for permission to execute this app in the background.\n\nThis is required in order to keep syncing while the app is not in the foreground",
 
     "messageSelectAccessMode": "Select a permission to create a share link",
-    "messageWaitingAccesMode":"Waiting for permission level",
 
     "replacementName":"{name}",
     "replacementPath":"{path}",

--- a/lib/l10n/intl_es.arb
+++ b/lib/l10n/intl_es.arb
@@ -27,7 +27,7 @@
     "typeFolder":"Directorio",
     "typeFile":"Archivo",
 
-    "labelRepositoryToken":"Token: ",
+    "labelRepositoryLink":"Link del repositorio: ",
     "labelName":"Nombre: ",
     "labelNewName":"Nuevo nombre: ",
     "labelLocation":"Localización: ",
@@ -89,7 +89,7 @@
     "messageDownloadingFileCanceled":"{name} - descarga cancelada",
 
     "messageMovingEntry":"Esta función no está disponible mientras se está moviendo una entrada",
-    "messageRepositoryToken":"Pegue el token aquí",
+    "messageRepositoryToken":"Pegue el link aquí",
     "messageRepositoryName":"De un nombre al repositorio",
     "messageRepositoryNewName":"Nuevo nombre del repositorio",
     "messageRepositoryAccessMode":"Modo de aceso otorgado: {access}",

--- a/lib/l10n/intl_es.arb
+++ b/lib/l10n/intl_es.arb
@@ -47,6 +47,8 @@
     "labelDownloadedTo":"Descargado en:",
 
     "labelSetPermission":"Determine el accesso",
+    "labelTokenLink":"Link del repositorio",
+    "labelCopyLink":"Copia el link",
     "labelShareLink":"Comparte el link",
 
     "messageLoadingDefault":"Cargando…",
@@ -131,6 +133,9 @@
 
     "messageBackgroundNotificationAndroid": "OuiSync está corriendo",
     "messageBackgroundAndroidPermissions": "En poco Android te predirá autorización para correr esta app en el trasfondo.\n\nEsto es requerido para poder continuar sincronizando mientras la app no está siendo usada activamente",
+
+    "messageSelectAccessMode": "Escoge el nivel de acceso para crear el link para compartir",
+    "messageWaitingAccesMode":"Esperando por el nivel de accesso",
 
     "replacementName":"{name}",
     "replacementPath":"{path}",

--- a/lib/l10n/intl_es.arb
+++ b/lib/l10n/intl_es.arb
@@ -135,7 +135,6 @@
     "messageBackgroundAndroidPermissions": "En poco Android te predirá autorización para correr esta app en el trasfondo.\n\nEsto es requerido para poder continuar sincronizando mientras la app no está siendo usada activamente",
 
     "messageSelectAccessMode": "Escoge el nivel de acceso para crear el link para compartir",
-    "messageWaitingAccesMode":"Esperando por el nivel de accesso",
 
     "replacementName":"{name}",
     "replacementPath":"{path}",


### PR DESCRIPTION
When sharing a repo, the drop-down widget to select the access mode for the share token was replaced with toggleable radio-buttons.

Also, the share link including the token is truncated to only include a few characters in the token fragment.
 