### PR TITLE
Fixed: dialog buttons overflow in lower res

### DIFF
--- a/lib/app/utils/dimensions.dart
+++ b/lib/app/utils/dimensions.dart
@@ -71,6 +71,8 @@ class Dimensions {
   static const double radiusSmall = 5.0;
   static const double radiusMicro = 2.0;
 
+  static const double aspectRatioModalDialogButton = 11 / 5;
+
   static const BoxConstraints sizeConstrainsDialogAction = BoxConstraints(minWidth: 98, minHeight: 46.0);
   static const double elevationDialogAction = 0.0;
 

--- a/lib/app/widgets/buttons/dialog_negative_button.dart
+++ b/lib/app/widgets/buttons/dialog_negative_button.dart
@@ -13,14 +13,20 @@ class NegativeButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      margin: Dimensions.marginDialogNegativeButton,
-      child: RawMaterialButton(
-        onPressed: onPressed,
-        child: Text((text ?? '').toUpperCase()),
-        constraints: Dimensions.sizeConstrainsDialogAction,
-        elevation: Dimensions.elevationDialogAction,
-        textStyle: Dimensions.textStyleDialogNegativeButton
-      ));
+    return Expanded(child: Row(
+      children: [
+        Expanded(child: Align(
+          alignment: Alignment.bottomRight,
+          child: AspectRatio(
+            aspectRatio: Dimensions.aspectRatioModalDialogButton,
+            child: Container(
+              margin: Dimensions.marginDialogNegativeButton,
+              child: RawMaterialButton(
+                onPressed: onPressed,
+                child: Text((text ?? '').toUpperCase()),
+                constraints: Dimensions.sizeConstrainsDialogAction,
+                elevation: Dimensions.elevationDialogAction,
+                textStyle: Dimensions.textStyleDialogNegativeButton,),),),),),
+      ],));
   }
 }

--- a/lib/app/widgets/buttons/dialog_positive_button.dart
+++ b/lib/app/widgets/buttons/dialog_positive_button.dart
@@ -13,20 +13,26 @@ class PositiveButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      margin: Dimensions.marginDialogPositiveButton,
-      child: RawMaterialButton(
-        onPressed: onPressed,
-        child: Text((text ?? '').toUpperCase()),
-        constraints: Dimensions.sizeConstrainsDialogAction,
-        elevation: Dimensions.elevationDialogAction,
-        fillColor: _fillColorStatus(context),
-        shape: const RoundedRectangleBorder(
-          borderRadius: Dimensions.borderRadiusDialogPositiveButton),
-        textStyle: TextStyle(
-          color: Theme.of(context).dialogBackgroundColor,
-          fontWeight: FontWeight.w500)
-      ));
+    return Expanded(child: Row(
+      children: [
+        Expanded(child: Align(
+          alignment: Alignment.bottomRight,
+          child: AspectRatio(
+            aspectRatio: Dimensions.aspectRatioModalDialogButton,
+            child: Container(
+              margin: Dimensions.marginDialogPositiveButton,
+              child: RawMaterialButton(
+                onPressed: onPressed,
+                child: Text((text ?? '').toUpperCase()),
+                constraints: Dimensions.sizeConstrainsDialogAction,
+                elevation: Dimensions.elevationDialogAction,
+                fillColor: _fillColorStatus(context),
+                shape: const RoundedRectangleBorder(
+                  borderRadius: Dimensions.borderRadiusDialogPositiveButton),
+                textStyle: TextStyle(
+                  color: Theme.of(context).dialogBackgroundColor,
+                  fontWeight: FontWeight.w500),),))))
+      ],));
   }
 
   Color _fillColorStatus(context) {


### PR DESCRIPTION
In lower resolutions, the positive and negative button in dialogs overflowed horizontally.

An `AspectRatio` widget is used to scale down each button size in lower resolutions.