### PR TITLE
CI optimize integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,7 @@ jobs:
   build_linux_and_android:
     name: build on linux and android
     runs-on: self-hosted
-    needs: [warmup_android]
+    needs: [build_integration_test_android] # to seed gradle cache
 
     steps:
       - uses: actions/checkout@v4
@@ -230,7 +230,7 @@ jobs:
   integration_test_android:
     name: "run integration tests on android ${{ matrix.api-level }}"
     runs-on: self-hosted
-    needs: [warmup_android]
+    needs: [build_integration_test_android]
     strategy:
       fail-fast: false
       matrix:
@@ -265,7 +265,8 @@ jobs:
             --container ouisync-integration-test-android-${{ matrix.api-level }}-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT \
             --srcdir . \
             --cache shared \
-            integration-test --platform android --api ${{ matrix.api-level }}
+            --artifact-id $GITHUB_RUN_ID \
+            integration-test --platform android --run --api ${{ matrix.api-level }}
 
       # - name: Upload logcat
       #   uses: actions/upload-artifact@v4
@@ -277,23 +278,25 @@ jobs:
       #   # Upload only when the tests fail
       #   if: failure() || cancelled()
 
-  warmup_android:
-    name: "warmup cache for android"
+  build_integration_test_android:
+    name: "build integration tests for android"
     runs-on: self-hosted
-    concurrency: # ensure this job runs only once at a time
-      group: warmup
+    concurrency: # ensure this job runs only once at a time because it needs exclusive cache access
+      group: prebuild
       cancel-in-progress: false
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - name: Warmup cache
+
+      - name: Build
         run: |
           ./docker/linux.sh \
-            --container ouisync-warmup-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT \
+            --container ouisync-build-integration-test-android-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT \
             --srcdir . \
             --cache exclusive \
-            warmup
+            --artifact-id $GITHUB_RUN_ID \
+            integration-test --platform android --build
 
   # TODO: Integration tests on both linux and windows currently fail or hang. Commenting them out until they are fixed.
   # integration_test_desktop:

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -46,6 +46,8 @@ android {
         versionCode = flutter.versionCode
         versionName = flutter.versionName
         multiDexEnabled = true
+
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
     signingConfigs {
@@ -95,7 +97,6 @@ android {
     }
 }
 
-
 // Generate launcher icons by invoking [icons_launcher](https://pub.dev/packages/icons_launcher)
 def isWindows = System.getProperty('os.name').toLowerCase().contains('windows')
 tasks.register("generateLauncherIcons", Exec) {
@@ -103,7 +104,7 @@ tasks.register("generateLauncherIcons", Exec) {
     // TODO: This generates icons for all platforms. Ideally we would restrict it to generate them
     // only for android (and set it up separately in other platforms' respective build systems).
     if (isWindows) {
-       commandLine 'cmd.exe', '/c', 'dart', 'run', 'icons_launcher:create'
+        commandLine 'cmd.exe', '/c', 'dart', 'run', 'icons_launcher:create'
     } else {
         commandLine 'dart', 'run', 'icons_launcher:create'
     }

--- a/android/app/src/androidTest/kotlin/org/equalitie/MainActivityTest.kt
+++ b/android/app/src/androidTest/kotlin/org/equalitie/MainActivityTest.kt
@@ -1,0 +1,17 @@
+package org.equalitie.ouisync
+
+import androidx.test.rule.ActivityTestRule
+import dev.flutter.plugins.integration_test.FlutterTestRunner
+import org.junit.Rule
+import org.junit.runner.RunWith
+
+@RunWith(FlutterTestRunner::class)
+class MainActivityTest {
+    @Rule
+    @JvmField
+    val rule = ActivityTestRule(
+        MainActivity::class.java,
+        /*initialTouchMode =*/ true,
+        /*launchActivity =*/ false,
+    )
+}

--- a/docker/linux.sh
+++ b/docker/linux.sh
@@ -16,9 +16,27 @@ shell=
 commit=
 # ... or rsync from the given host directory.
 srcdir=
-# Whether to also include the .git directory when copying the source directory into the container.
-# Including it is currently necessary when running the `build` command only.
-rsync_include_git=
+
+# Which files/directories to include/exclude when rsyncing from `srcdir` to the container.
+rsync_exclude=(
+    .dart_tool
+    .git
+    android/app/.cxx
+    build
+    ios
+    linux/flutter/ephemeral
+    ouisync/.git
+    ouisync/target
+    releases
+    tmp
+    windows/flutter/ephemeral
+)
+rsync_include=
+
+
+# A host directory mounted to /opt/ouisync-app/build in the container. Useful to retrieve artifacts
+# after a build.
+mount_build_dir=
 
 base_name="ouisync-runner-linux"
 default_image_name="$base_name:$USER"
@@ -134,16 +152,17 @@ function print_help() {
             echo "    --container <NAME>         Assign a name to the docker container [default: $default_container_name]"
             echo "    --image <NAME>[:TAG]       Name (and optional tag) of the docker image to use [default: $default_image_name]"
             echo "    --cache <shared|exclusive> Cache some dependencies and intermediate build artifacts on a persistent docker volume"
+            echo "    --mount-build-dir <PATH>   Mount <PATH> into the ouisync-app's build dir on the container (/opt/ouisync-app/build)"
             echo "    -s, --shell                Open a shell session in the container after the command finishes"
             echo
             echo "Commands:"
-            echo "    help              Print help"
-            echo "    build             Build release"
-            echo "    unit-test         Run unit tests"
-            echo "    integration-test  Run integration tests"
-            echo "    analyze           Analyze the dart source code"
-            echo "    container         Explicitly manage the container"
-            echo "    warmup            Warmup cache for android tests and builds"
+            echo "    help                       Print help"
+            echo "    build                      Build release"
+            echo "    unit-test                  Run unit tests"
+            echo "    integration-test           Run integration tests"
+            echo "    analyze                    Analyze the dart source code"
+            echo "    container                  Explicitly manage the container"
+            echo "    warmup                     Warmup cache for android tests and builds"
             echo
             echo "See '$0 help <command> for more information on a specific command"
             ;;
@@ -241,6 +260,11 @@ function start_container() {
     # what we want because we create the AVD from scratch on every run anyway.
     opts="$opts --mount dst=/root/.android"
 
+    # Mount ouisync-app build dir
+    if [ -n "$mount_build_dir" ]; then
+        opts="$opts --mount type=bind,src=$(realpath $mount_build_dir),dst=/opt/ouisync-app/build"
+    fi
+
     # Needed for android emulator
     opts="$opts --device /dev/kvm"
 
@@ -281,15 +305,17 @@ function start_container() {
     fi
     log_group_end
 
-    # Generate bindings (TODO: This should be done automatically)
-    log_group_begin "Generate bindings"
-    exe -w /opt/ouisync-app/ouisync/bindings/dart -t dart pub get
-    exe -w /opt/ouisync-app/ouisync/bindings/dart -t dart tool/bindgen.dart
-    log_group_end
+    if exe test -f /opt/ouisync-app/pubspec.yaml; then
+        # Generate bindings (TODO: This should be done automatically)
+        log_group_begin "Generate bindings"
+        exe -w /opt/ouisync-app/ouisync/bindings/dart -t dart pub get
+        exe -w /opt/ouisync-app/ouisync/bindings/dart -t dart tool/bindgen.dart
+        log_group_end
 
-    log_group_begin "Update dart dependencies"
-    exe -w /opt/ouisync-app -t dart pub get
-    log_group_end
+        log_group_begin "Update dart dependencies"
+        exe -w /opt/ouisync-app -t dart pub get
+        log_group_end
+    fi
 
     if [ -n "$cache" ]; then
         # Run cargo sweep to delete all cargo artifacts older than 30 days (prevents unbounded cache grow)
@@ -369,8 +395,6 @@ function init() {
 ####################################################################################################
 # Build the release artifacts for linux and android
 function build() {
-    rsync_include_git=1
-
     local dst_dir=
     local flavor=
     local types=()
@@ -402,6 +426,9 @@ function build() {
         esac
         shift
     done
+
+    # .git is needed for release.dart script to read git commit
+    rsync_exclude=("${rsync_exclude[@]/.git}")
 
     local secret_sentry_dsn=
     local secret_store_password=
@@ -627,9 +654,9 @@ function emulator_stop() {
 }
 
 function integration_test_android() {
-    init
-
     local api=
+    local build=
+    local run=
 
     while true; do
         case ${1-} in
@@ -637,24 +664,90 @@ function integration_test_android() {
                 api="${2-}"
                 shift 2
                 ;;
+            --build)
+                build=1
+                shift
+                ;;
+            --run)
+                run=1
+                shift
+                ;;
             *)
                 break
                 ;;
         esac
     done
 
-    if [ -z "$api" ]; then
+    if [ -z "$build" -a -z "$run" ]; then
+        error "Missing --build and/or --run"
+    fi
+
+    if [ -n "$run" -a -z "$api" ]; then
         error "Missing --api"
     fi
 
-    emulator_start --api $api
+    if [ -z "$build" ]; then
+        # When we are only running the tests, not building them, we don't need the whole source.
+        # Just these files:
+        rsync_include=("/util/" "/util/adb-format-sdcard.sh")
+        rsync_exclude=("*")
+    fi
 
-    log_group_begin "Run tests"
-    exe -w /opt/ouisync-app -t \
-        flutter test integration_test --flavor itest --ignore-timeouts $@
-    log_group_end
+    init
 
-    emulator_stop
+    local build_dir=/opt/ouisync-app/build/app/outputs/apk
+    local app_path="$build_dir/itest/debug/app-itest-debug.apk"
+    local test_path="$build_dir/androidTest/itest/debug/app-itest-debug-androidTest.apk"
+
+    # Build the instrumented app
+    if [ -n "$build" ]; then
+        log_group_begin "Build app"
+        exe -w /opt/ouisync-app -t \
+            flutter build apk \
+                --debug \
+                --flavor itest \
+                --target-platform android-x64 \
+            --target integration_test/app_test.dart
+        log_group_end
+
+        log_group_begin "Build androidTest"
+        exe -w /opt/ouisync-app/android -t ./gradlew app:assembleItestDebugAndroidTest
+        log_group_end
+    fi
+
+    # Run the tests
+    if [ -n "$run" ]; then
+        exe test -f $app_path  || exit "Missing $app_path - rerun with --build"
+        exe test -f $test_path || exit "Missing $test_path - rerun with --build"
+
+        emulator_start --api $api
+
+        log_group_begin "Install"
+        exe adb install -r $app_path
+        exe adb install -r $test_path
+        log_group_end
+
+        log_group_begin "Run tests"
+
+        # HACK: `adb shell am instrument` returns success error code even on test failure. Need to
+        # parse the output to find out the test result.
+        output=$(mktemp)
+        exe -t adb shell am instrument -w \
+            org.equalitie.ouisync.itest.test/androidx.test.runner.AndroidJUnitRunner \
+            2>&1 \
+            | tee $output
+
+        result=0
+        grep -qE "^OK \(" $output || result=$?
+
+        log_group_end
+
+        emulator_stop
+
+        if [ "$result" != 0 ]; then
+            exit "$result"
+        fi
+    fi
 }
 
 function integration_test_linux() {
@@ -760,6 +853,10 @@ while true; do
                     ;;
             esac
             ;;
+        --mount-build-dir)
+            mount_build_dir="$2"
+            shift
+            ;;
         -s|--shell)
             shell=1
             ;;
@@ -788,6 +885,9 @@ case "${1-}" in
         ;;
     integration-test|integration-tests|it)
         integration_test ${@:2}
+        ;;
+    prebuild-integration-test|prebuild-integration-tests)
+        prebuild_integration_test ${@:2}
         ;;
     analyze)
         analyze ${@:2}

--- a/docker/linux.sh
+++ b/docker/linux.sh
@@ -18,25 +18,19 @@ commit=
 srcdir=
 
 # Which files/directories to include/exclude when rsyncing from `srcdir` to the container.
-rsync_exclude=(
-    .dart_tool
-    .git
-    android/app/.cxx
-    build
-    ios
-    linux/flutter/ephemeral
-    ouisync/.git
-    ouisync/target
-    releases
-    tmp
-    windows/flutter/ephemeral
+rsync_filter=(
+    "--exclude=.dart_tool"
+    "--exclude=.git"
+    "--exclude=android/app/.cxx"
+    "--exclude=build"
+    "--exclude=ios"
+    "--exclude=linux/flutter/ephemeral"
+    "--exclude=ouisync/.git"
+    "--exclude=ouisync/target"
+    "--exclude=releases"
+    "--exclude=tmp"
+    "--exclude=windows/flutter/ephemeral"
 )
-rsync_include=
-
-
-# A host directory mounted to /opt/ouisync-app/build in the container. Useful to retrieve artifacts
-# after a build.
-mount_build_dir=
 
 base_name="ouisync-runner-linux"
 default_image_name="$base_name:$USER"
@@ -85,6 +79,13 @@ exclusive_cache_paths=(
 )
 
 emulator_sdcard=32M
+
+# If specified, the build artifacts are placed into a directory on a shared named volume. This
+# allows two jobs that use the same `artifact_id` to share the artifacts, e.g., one job creates
+# them and the other uses them.
+artifact_id=
+artifact_volume="$base_name-artifacts"
+artifact_retention_days=7
 
 function print_help() {
     local command="${1:-}"
@@ -152,7 +153,7 @@ function print_help() {
             echo "    --container <NAME>         Assign a name to the docker container [default: $default_container_name]"
             echo "    --image <NAME>[:TAG]       Name (and optional tag) of the docker image to use [default: $default_image_name]"
             echo "    --cache <shared|exclusive> Cache some dependencies and intermediate build artifacts on a persistent docker volume"
-            echo "    --mount-build-dir <PATH>   Mount <PATH> into the ouisync-app's build dir on the container (/opt/ouisync-app/build)"
+            echo "    --artifact_id              Place build artifacts in a directory with this name on a shared named volume, for reuse"
             echo "    -s, --shell                Open a shell session in the container after the command finishes"
             echo
             echo "Commands:"
@@ -206,6 +207,27 @@ function setup_cache_overlays() {
     log_group_end
 }
 
+function create_artifact_volume() {
+    log_group_begin "Create artifact volume $artifact_volume"
+
+    local common_opts=" \
+        --rm \
+        --mount src=$artifact_volume,dst=/mnt/artifacts \
+        --workdir /mnt/artifacts \
+        $image_name \
+    "
+
+    dock volume create $artifact_volume > /dev/null
+
+    # Prune old artifact directories
+    dock run $common_opts find . -type d -ctime +$artifact_retention_days -exec rm -rf {} \;
+
+    # Create new artifacts directory
+    dock run $common_opts mkdir -p "$artifact_id"
+
+    log_group_end
+}
+
 function start_container() {
     if [ -z "$commit" -a -z "$srcdir" ]; then error "Missing one of --commit or --srcdir"; fi
     if [ -n "$commit" -a -n "$srcdir" ]; then error "--commit and --srcdir are mutually exclusive"; fi
@@ -221,6 +243,10 @@ function start_container() {
 
     if [ -n "$cache" ]; then
         create_cache_volume
+    fi
+
+    if [ -n "$artifact_id" ]; then
+        create_artifact_volume
     fi
 
     log_group_begin "Start container $container_name"
@@ -255,15 +281,15 @@ function start_container() {
         fi
     fi
 
+    # Mount artifacts volume
+    if [ -n "$artifact_id" ]; then
+        opts="$opts --mount src=$artifact_volume,dst=/opt/ouisync-app/build/app/outputs,volume-subpath=$artifact_id"
+    fi
+
     # Mount anonymous volume to put the AVDs on. This is because they work better on a real
     # filesystem rather than on overlay. The volume is destroyed when the container stops which is
     # what we want because we create the AVD from scratch on every run anyway.
     opts="$opts --mount dst=/root/.android"
-
-    # Mount ouisync-app build dir
-    if [ -n "$mount_build_dir" ]; then
-        opts="$opts --mount type=bind,src=$(realpath $mount_build_dir),dst=/opt/ouisync-app/build"
-    fi
 
     # Needed for android emulator
     opts="$opts --device /dev/kvm"
@@ -427,8 +453,8 @@ function build() {
         shift
     done
 
-    # .git is needed for release.dart script to read git commit
-    rsync_exclude=("${rsync_exclude[@]/.git}")
+    # Don't exclude '.git' because it's needed for release.dart script to read git commit
+    rsync_filter=("${rsync_filter[@]/"--exclude=.git"}")
 
     local secret_sentry_dsn=
     local secret_store_password=
@@ -688,9 +714,12 @@ function integration_test_android() {
 
     if [ -z "$build" ]; then
         # When we are only running the tests, not building them, we don't need the whole source.
-        # Just these files:
-        rsync_include=("/util/" "/util/adb-format-sdcard.sh")
-        rsync_exclude=("*")
+        # Just a few files:
+        rsync_filter=(
+            "--include=/util/"
+            "--include=/util/adb-format-sdcard.sh"
+            "--exclude=*"
+        )
     fi
 
     init
@@ -702,11 +731,10 @@ function integration_test_android() {
     # Build the instrumented app
     if [ -n "$build" ]; then
         log_group_begin "Build app"
-        exe -w /opt/ouisync-app -t \
-            flutter build apk \
-                --debug \
-                --flavor itest \
-                --target-platform android-x64 \
+        exe -w /opt/ouisync-app -t flutter build apk \
+            --debug \
+            --flavor itest \
+            --target-platform android-x64 \
             --target integration_test/app_test.dart
         log_group_end
 
@@ -853,8 +881,8 @@ while true; do
                     ;;
             esac
             ;;
-        --mount-build-dir)
-            mount_build_dir="$2"
+        --artifact-id)
+            artifact_id="$2"
             shift
             ;;
         -s|--shell)
@@ -885,9 +913,6 @@ case "${1-}" in
         ;;
     integration-test|integration-tests|it)
         integration_test ${@:2}
-        ;;
-    prebuild-integration-test|prebuild-integration-tests)
-        prebuild_integration_test ${@:2}
         ;;
     analyze)
         analyze ${@:2}

--- a/docker/utils.sh
+++ b/docker/utils.sh
@@ -86,25 +86,6 @@ function get_sources_from_local_dir {
     local srcdir=$1
     local dstdir=$2
 
-    local exclude_dirs=(
-        .dart_tool
-        android/app/.cxx
-        build
-        ios
-        linux/flutter/ephemeral
-        ouisync/.git
-        ouisync/target
-        releases
-        tmp
-        windows/flutter/ephemeral
-    )
-
-    # .git is needed for release.dart script to read git commit
-    if [ "$rsync_include_git" != 1 ]; then
-        exclude_dirs+=(.git)
-    fi
-
-
     local host_opt=
     local compress_opt=
 
@@ -116,7 +97,8 @@ function get_sources_from_local_dir {
     rsync -e "docker $host_opt exec -i" \
         --archive --no-links --verbose \
         $compress_opt \
-        ${exclude_dirs[@]/#/--exclude=} \
+        ${rsync_include[@]/#/--include=} \
+        ${rsync_exclude[@]/#/--exclude=} \
         ${srcdir%/}/ $container_name:$dstdir/ouisync-app
 
     exe git config --global --add safe.directory /opt/ouisync-app

--- a/docker/utils.sh
+++ b/docker/utils.sh
@@ -94,11 +94,15 @@ function get_sources_from_local_dir {
         compress_opt="--compress"
     fi
 
+    local filter_opts=()
+    for f in "${rsync_filter[@]}"; do
+        filter_opts+=("--filter=${f:0:1} ${f:1}")
+    done
+
     rsync -e "docker $host_opt exec -i" \
         --archive --no-links --verbose \
         $compress_opt \
-        ${rsync_include[@]/#/--include=} \
-        ${rsync_exclude[@]/#/--exclude=} \
+        ${rsync_filter[@]} \
         ${srcdir%/}/ $container_name:$dstdir/ouisync-app
 
     exe git config --global --add safe.directory /opt/ouisync-app


### PR DESCRIPTION
Split building and running integration tests, then build them once and run many times (once per API version)